### PR TITLE
Fix mask and vaccine intervention semantics

### DIFF
--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -207,23 +207,30 @@ def apply_person_interventions(
     interventions: dict,
     ts_str: str,
 ) -> None:
-    if person.iv_threshold <= interventions["mask"]:
-        if not person.is_masked():
-            simulator.log_event("log_intervention_effect", person, "mask", "complied", ts_str)
+    # Masking is reversible: lowering the policy unmasks previously compliant people.
+    should_mask = person.iv_threshold <= interventions["mask"]
+    if should_mask and not person.is_masked():
+        simulator.log_event("log_intervention_effect", person, "mask", "complied", ts_str)
         person.set_masked(True)
+    elif not should_mask and person.is_masked():
+        simulator.log_event("log_intervention_effect", person, "mask", "unmasked", ts_str)
+        person.set_masked(False)
 
-    if person.iv_threshold <= interventions["vaccine"]:
+    # Vaccination is permanent and dose count is locked at first inoculation.
+    if (
+        person.iv_threshold <= interventions["vaccine"]
+        and person.get_vaccinated() == VaccinationState.NONE
+    ):
         min_doses = SIMULATION["vaccination_options"]["min_doses"]
         max_doses = SIMULATION["vaccination_options"]["max_doses"]
         doses = random.randint(min_doses, max_doses)
-        if person.get_vaccinated() == VaccinationState.NONE:
-            simulator.log_event(
-                "log_intervention_effect",
-                person,
-                "vaccine",
-                f"received_{doses}_doses",
-                ts_str,
-            )
+        simulator.log_event(
+            "log_intervention_effect",
+            person,
+            "vaccine",
+            f"received_{doses}_doses",
+            ts_str,
+        )
         person.set_vaccinated(VaccinationState(doses))
 
 

--- a/tests/test_simulator_refactor.py
+++ b/tests/test_simulator_refactor.py
@@ -10,7 +10,13 @@ import requests
 from simulator.event_queue import EventQueue
 from simulator.infectionmgr import InfectionManager
 from simulator.pap import Facility, Household, InfectionState, InfectionTimeline, Person, VaccinationState
-from simulator.runner import LoadedSimulationData, SimulationRunner, move_people, normalize_simdata
+from simulator.runner import (
+    LoadedSimulationData,
+    SimulationRunner,
+    apply_person_interventions,
+    move_people,
+    normalize_simdata,
+)
 from simulator.snapshots import SimulationSnapshotWriter, build_movement_snapshot
 from simulator.world import DiseaseSimulator, build_locations, seed_population
 from simulator.infection_models.v6_wells_riley import CAT, get_vaccination_protection
@@ -298,6 +304,60 @@ class TestSimulatorRefactor(unittest.TestCase):
                     infector=infector,
                 )
             )
+
+    def test_masking_intervention_unmasks_when_policy_is_lowered(self):
+        simulator = make_simulator()
+        home = Household("cbg-home", "home")
+        person = Person("p1", 0, 30, home)
+        person.iv_threshold = 0.3
+
+        apply_person_interventions(
+            simulator,
+            person,
+            {"mask": 0.5, "vaccine": 0.0},
+            "0",
+        )
+        self.assertTrue(person.is_masked())
+
+        apply_person_interventions(
+            simulator,
+            person,
+            {"mask": 0.2, "vaccine": 0.0},
+            "60",
+        )
+        self.assertFalse(person.is_masked())
+
+    def test_vaccination_intervention_does_not_re_randomize_doses(self):
+        simulator = make_simulator()
+        home = Household("cbg-home", "home")
+        person = Person("p1", 0, 30, home)
+        person.iv_threshold = 0.1
+        person.set_vaccinated(VaccinationState.PARTIAL)
+
+        apply_person_interventions(
+            simulator,
+            person,
+            {"mask": 0.0, "vaccine": 0.5},
+            "60",
+        )
+
+        self.assertEqual(person.get_vaccinated(), VaccinationState.PARTIAL)
+
+    def test_vaccination_intervention_assigns_doses_on_first_application(self):
+        simulator = make_simulator()
+        home = Household("cbg-home", "home")
+        person = Person("p1", 0, 30, home)
+        person.iv_threshold = 0.1
+
+        with mock.patch("simulator.runner.random.randint", return_value=2):
+            apply_person_interventions(
+                simulator,
+                person,
+                {"mask": 0.0, "vaccine": 0.5},
+                "0",
+            )
+
+        self.assertEqual(person.get_vaccinated(), VaccinationState.IMMUNIZED)
 
     def test_normalize_simdata_exposes_runtime_contract_defaults(self):
         normalized = normalize_simdata({


### PR DESCRIPTION
## Summary
- Masking now follows the policy value in both directions: lowering the intervention unmasks people whose threshold sits above the new value (previously irreversible).
- Vaccination is treated as a one-time event per person — dose count is locked at first inoculation rather than re-randomized on every subsequent intervention change (previously could downgrade IMMUNIZED → PARTIAL).
- Adds three regression tests in `tests/test_simulator_refactor.py` covering both behaviors.

## Test plan
- [x] `pytest tests/test_simulator_refactor.py` — 15 passed (12 existing + 3 new)
- [x] Manual: two-row mask timeline (0.6 → 0.1) emits `unmasked` events at the lowered hour
- [ ] Reviewer: confirm vaccine cumulative-only semantics is the intended model

🤖 Generated with [Claude Code](https://claude.com/claude-code)