### PR TITLE
Isolate iv_thresholds shuffle on its own RNG

### DIFF
--- a/simulator/world.py
+++ b/simulator/world.py
@@ -133,17 +133,17 @@ def seed_population(
     infection_manager,
     initial_infected_count: int,
 ) -> PopulationBuildResult:
-    # Pre-shuffle the threshold list and consume it linearly. The original
-    # code did random.choice(L) followed by L.remove(value) per person, which
-    # is O(n^2) over ~50k people. A single shuffle + linear iteration produces
-    # the same statistical distribution (each person gets a distinct threshold,
-    # drawn uniformly without replacement) in O(n). Specific person-to-threshold
-    # bijection differs, so downstream simdata/movement hashes shift.
+    # Threshold-to-person assignment is a uniform-without-replacement bijection
+    # whose only role is labeling — the threshold *distribution* is uniform
+    # regardless of which person gets which value, so this draw has no
+    # epidemiological meaning. We isolate it on its own Random so it can't
+    # perturb the global stream that Wells-Riley, lockdown checks, and seed
+    # sampling consume from.
     iv_thresholds = [
         ceil((100.0 * index) / len(people_data)) / 100.0
         for index in range(len(people_data))
     ]
-    random.shuffle(iv_thresholds)
+    random.Random(0).shuffle(iv_thresholds)
     threshold_iter = iter(iv_thresholds)
 
     # Holds Person object refs so update_people_states can iterate without a


### PR DESCRIPTION
## Summary

Determinism hygiene fix in `seed_population` ([simulator/world.py](simulator/world.py)). Phase 1 sped up per-person intervention-threshold assignment by replacing an O(n²) `random.choice + remove` loop with a single `random.shuffle(iv_thresholds)`. Correct as sampling, but the shuffle drew from the **global** `random` stream, so it shifted the stream position for every downstream consumer (Wells-Riley transmission draws, lockdown/self-iso checks, seed sampling). That coupling means any future change to this loop silently drifts downstream infection counts.

One-line change:
```python
random.shuffle(iv_thresholds)  →  random.Random(0).shuffle(iv_thresholds)
```
The shuffle now runs on a dedicated RNG, taking zero draws from the global stream. The threshold-to-person assignment is pure labeling (the distribution is uniform regardless of order), so a fixed-seed shuffle has no epidemiological meaning.

## Notes
- This does **not** restore the exact pre-phase-1 hash — the bijection itself differs from the old `choice + remove` pattern. The value is forward-looking: changes to this loop no longer perturb downstream RNG consumers.
- Independent of the in-process DMP work in #6.

## Test plan
- [x] `pytest tests/test_simulator_refactor.py` — 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)