### PR TITLE
Serialize simulation snapshots with orjson

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ narwhals==2.16.0
 networkx==3.5
 numba==0.62.1
 numpy==2.3.3
+orjson==3.11.5
 packaging==25.0
 pandas==2.3.3
 pathlib_mate==1.3.2

--- a/simulator/io.py
+++ b/simulator/io.py
@@ -1,6 +1,24 @@
 import gzip
-import json
 import os
+
+# Snapshot values are pure JSON-native (str/int/list, str-keyed dicts), so the
+# serializer only needs the common path. orjson is ~2-4x faster than the stdlib
+# json encoder on this shape; fall back to stdlib json (compact) when it isn't
+# installed so the simulator still runs. Both emit bytes for the gzip stream.
+try:
+    import orjson
+
+    def _dumps(obj) -> bytes:
+        return orjson.dumps(obj)
+
+    HAVE_ORJSON = True
+except ImportError:  # pragma: no cover - exercised only without orjson
+    import json
+
+    def _dumps(obj) -> bytes:
+        return json.dumps(obj, separators=(",", ":")).encode("utf-8")
+
+    HAVE_ORJSON = False
 
 # gzip's default compresslevel is 9 (maximum). At ZIP 74002 / 168h that costs
 # ~47s of pure compression CPU per simulation. Level 1 is the fastest gzip
@@ -15,21 +33,25 @@ class IncrementalJSONWriter:
         self.filename = filename
         level = _DEFAULT_GZIP_LEVEL if compresslevel is None else compresslevel
 
-        # Use gzip.open for compressed writing
-        self.f = gzip.open(filename, 'wt', encoding='utf-8', compresslevel=level)
-        self.f.write('{')
+        # Binary mode: orjson emits bytes (and the json fallback is encoded to
+        # utf-8 bytes), and the structural tokens are written as bytes too.
+        self.f = gzip.open(filename, "wb", compresslevel=level)
+        self.f.write(b"{")
         self.first = True
 
     def add(self, key, value):
         if not self.first:
-            self.f.write(',')
+            self.f.write(b",")
         else:
             self.first = False
 
-        # We manually structure the key-value pair to avoid dumping a huge wrapper dict
-        self.f.write(f'"{key}":')
-        json.dump(value, self.f)
+        # Serialize the key as a proper JSON string (handles escaping) followed
+        # by the value. We structure the pair manually to avoid materializing
+        # one huge wrapper dict across all timesteps.
+        self.f.write(_dumps(str(key)))
+        self.f.write(b":")
+        self.f.write(_dumps(value))
 
     def close(self):
-        self.f.write('}')
+        self.f.write(b"}")
         self.f.close()


### PR DESCRIPTION
## Summary

After the in-process DMP fix (#6), `write_snapshot/writer_write` became the top simulator cost — stdlib `json.dump` into a text-mode gzip stream, once per timestep. Snapshot values are pure JSON-native (str/int/list, str-keyed dicts), so this swaps the writer to **orjson over a binary gzip stream**, with a stdlib-json fallback so the simulator still runs if orjson is absent.

### Measured (168h, DMP off, same scenario)
| | before (json) | after (orjson) |
|---|---:|---:|
| `writer_write` | 5.09s | **0.68s** (7.4x) |
| simulation total | 21.5s | 14.9s |

On a 30-day in-process run this takes `write_snapshot` from ~32s toward ~16s (~17% off the whole run).

## Changes
- `simulator/io.py`: `IncrementalJSONWriter` uses orjson + binary gzip; stdlib-json (compact) fallback.
- `requirements.txt`: add `orjson==3.11.5`.

## Equivalence
Output is semantically identical — only whitespace differs (orjson compact vs json spaced). The existing snapshot-writer round-trip test passes unchanged; full suite 15/15.

## Test plan
- [x] `pytest tests/test_simulator_refactor.py` — 15/15 (incl. `test_snapshot_writer_writes_expected_gzip_output`)
- [x] writer_write timing before/after on identical scenario
- [ ] Reviewer: confirm deploy installs `orjson` (in requirements; soft-fallback if not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)