### PR TITLE
Add behavioral golden guard to perf_bench (SoA Stage 0)

### DIFF
--- a/scripts/perf_bench.py
+++ b/scripts/perf_bench.py
@@ -1,20 +1,31 @@
 #!/usr/bin/env python3
-"""Minimal sim-stage performance harness.
+"""Minimal sim-stage performance harness + behavioral golden guard.
 
-Times `simulate.run_simulator` against a cached papdata + patterns pair,
+Times `SimulationRunner.run` against a cached papdata + patterns pair,
 N measured runs after a discarded smoke run (covers JIT warmup and
-import-side-effect noise). Re-seeds Python and numpy RNGs before each
-run for reproducibility. Hashes the resulting simdata.json.gz so a
-behavioral drift between runs or branches is visible.
+import-side-effect noise). Re-seeds Python and numpy RNGs before each run
+for reproducibility, and reports a fast file hash so timing-run drift is
+visible at a glance.
+
+Golden guard (--write-golden / --check-golden): freezes a behavioral
+fingerprint — a *canonical* content hash of simdata and patterns plus the
+total infected count — at a fixed seed/length/dmp-mode. The canonical hash
+decompresses, parses, and re-serializes with sorted keys, so it is immune
+to serialization-format changes (orjson vs json, gzip level, key order)
+and trips only on a genuine change in simulation output. This is the guard
+rail for representation-only refactors (e.g. struct-of-arrays), which must
+keep output byte-identical.
 
 Usage:
-    scripts/perf_bench.py \\
-        --sim-root /path/to/Simulation/_worktrees/phase2a-numba-transmission \\
-        --papdata  /Users/ryad/Code/delineo/Fullstack/db/be97844d-527d-4057-b5a0-cd74653041b7.gz \\
-        --patterns /Users/ryad/Code/delineo/Fullstack/db/5e2cfba0-bb54-4e12-8588-dd55e14a40c3.gz \\
-        --runs 3 --length 1440 --label baseline
+    scripts/perf_bench.py --sim-root <root> --papdata <gz> --patterns <gz> \\
+        --length 2880 --runs 3 --dmp-mode off --label baseline
 
-Emits a summary JSON on stdout; per-run progress on stderr.
+    # freeze a golden, then later check against it:
+    scripts/perf_bench.py ... --write-golden _perf-runs/golden.json
+    scripts/perf_bench.py ... --check-golden _perf-runs/golden.json
+
+Emits a summary JSON on stdout; per-run progress on stderr. In
+--check-golden mode, exits non-zero on drift.
 """
 from __future__ import annotations
 
@@ -31,14 +42,30 @@ import tempfile
 import time
 from pathlib import Path
 
+# Populated by the InfectionManager.__init__ monkeypatch so we can read the
+# final infected set after a run without the runner exposing it.
+_captured: dict = {}
+
 
 def hash_file(path: Path) -> str:
+    """Fast hash of the raw (gzipped) bytes — sensitive to serialization
+    format. Used for the cheap per-run consistency check."""
     h = hashlib.sha256()
     opener = gzip.open if str(path).endswith(".gz") else open
     with opener(path, "rb") as f:
         for chunk in iter(lambda: f.read(1 << 20), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def canonical_hash(path: Path) -> str:
+    """Format-agnostic content hash: decompress, parse, re-serialize with
+    sorted keys. Immune to whitespace/gzip-level/key-order changes; trips
+    only on a change in the actual data."""
+    with gzip.open(path, "rb") as f:
+        data = json.loads(f.read())
+    canon = json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canon).hexdigest()
 
 
 def parse_args() -> argparse.Namespace:
@@ -56,6 +83,10 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--dmp-mode", default="auto", choices=["auto", "required", "off"],
                    help="DMP timeline source. 'off' uses the local fallback and "
                         "skips the per-infection HTTP call (default: auto)")
+    p.add_argument("--write-golden", metavar="PATH",
+                   help="Write a behavioral golden (canonical hashes + infected) to PATH")
+    p.add_argument("--check-golden", metavar="PATH",
+                   help="Check the run against a golden at PATH; exit 1 on drift")
     return p.parse_args()
 
 
@@ -63,6 +94,7 @@ def main() -> int:
     import numpy as np  # imported here to avoid before-args side effects
 
     args = parse_args()
+    golden_mode = bool(args.write_golden or args.check_golden)
 
     sim_root = Path(args.sim_root).resolve()
     if not (sim_root / "simulator").is_dir():
@@ -71,17 +103,27 @@ def main() -> int:
 
     sys.path.insert(0, str(sim_root))
     from simulator.runner import SimulationRunner  # type: ignore[import-not-found]
+    import simulator.infectionmgr as _infmod  # type: ignore[import-not-found]
+
+    # Capture the InfectionManager so we can read its final infected set (total
+    # ever infected) — the human-readable companion to the canonical hashes.
+    _orig_init = _infmod.InfectionManager.__init__
+
+    def _cap_init(self, *a, **k):
+        _orig_init(self, *a, **k)
+        _captured["mgr"] = self
+
+    _infmod.InfectionManager.__init__ = _cap_init
 
     papdata_path = Path(args.papdata).resolve()
     patterns_path = Path(args.patterns).resolve()
 
-    # Pre-load papdata + patterns once and reuse across runs. The default
-    # data_loader hits the Fullstack dev server over HTTP; we replace it
-    # with a closure that returns the cached pair directly.
     def _load_json_gz(path: Path):
         with gzip.open(path, "rt", encoding="utf-8") as fh:
             return json.load(fh)
 
+    # Pre-load papdata + patterns once and reuse; the default data_loader hits
+    # the Fullstack dev server over HTTP, which we bypass with a closure.
     cached_papdata = _load_json_gz(papdata_path)
     cached_patterns = _load_json_gz(patterns_path)
 
@@ -89,17 +131,14 @@ def main() -> int:
         return cached_papdata, cached_patterns
 
     interventions = [{
-        "time": 0,
-        "mask": 0.0,
-        "vaccine": 0.0,
-        "capacity": 1.0,
-        "lockdown": 0.0,
-        "selfiso": 0.0,
+        "time": 0, "mask": 0.0, "vaccine": 0.0,
+        "capacity": 1.0, "lockdown": 0.0, "selfiso": 0.0,
     }]
 
-    def one_run(label: str) -> tuple[float, str]:
+    def one_run(label: str, want_canonical: bool = False) -> dict:
         random.seed(args.seed)
         np.random.seed(args.seed)
+        _captured.clear()
         with tempfile.TemporaryDirectory() as td:
             payload = {
                 "length": args.length,
@@ -112,11 +151,8 @@ def main() -> int:
             t0 = time.perf_counter()
             with contextlib.redirect_stdout(logs), contextlib.redirect_stderr(logs):
                 runner = SimulationRunner(
-                    simdata=payload,
-                    enable_logging=False,
-                    output_dir=td,
-                    progress_callback=None,
-                    data_loader=local_loader,
+                    simdata=payload, enable_logging=False, output_dir=td,
+                    progress_callback=None, data_loader=local_loader,
                 )
                 result = runner.run()
             elapsed = time.perf_counter() - t0
@@ -126,46 +162,84 @@ def main() -> int:
                     f"--- logs ---\n{logs.getvalue()}"
                 )
             simdata_path = Path(result["simdata"])
+            patterns_out = Path(result["patterns"])
             if not simdata_path.is_file():
-                raise RuntimeError(
-                    f"expected simdata at {simdata_path} but file is missing; "
-                    f"result keys={list(result)}"
-                )
-            sha = hash_file(simdata_path)
-        return elapsed, sha
+                raise RuntimeError(f"missing simdata at {simdata_path}; keys={list(result)}")
+            out = {"elapsed": elapsed, "file_sha": hash_file(simdata_path)}
+            if want_canonical:
+                out["simdata_canon"] = canonical_hash(simdata_path)
+                out["patterns_canon"] = canonical_hash(patterns_out)
+        mgr = _captured.get("mgr")
+        out["infected"] = len(mgr.infected) if mgr is not None else None
+        return out
 
     timings: list[float] = []
     hashes: list[str] = []
 
-    smoke_elapsed, smoke_sha = one_run("smoke")
-    print(f"[{args.label}] smoke   {smoke_elapsed:6.2f}s  sha={smoke_sha[:16]}", file=sys.stderr)
+    smoke = one_run("smoke")
+    print(f"[{args.label}] smoke   {smoke['elapsed']:6.2f}s  sha={smoke['file_sha'][:16]}", file=sys.stderr)
 
+    # In golden mode, capture canonical fingerprint on the first measured run.
+    fingerprint: dict = {}
     for i in range(args.runs):
-        elapsed, sha = one_run(f"measured-{i+1}")
-        timings.append(elapsed)
-        hashes.append(sha)
-        print(f"[{args.label}] meas {i+1}  {elapsed:6.2f}s  sha={sha[:16]}", file=sys.stderr)
+        r = one_run(f"measured-{i+1}", want_canonical=(golden_mode and i == 0))
+        timings.append(r["elapsed"])
+        hashes.append(r["file_sha"])
+        if golden_mode and i == 0:
+            fingerprint = {
+                "simdata_canon_sha": r["simdata_canon"],
+                "patterns_canon_sha": r["patterns_canon"],
+                "infected": r["infected"],
+            }
+        print(f"[{args.label}] meas {i+1}  {r['elapsed']:6.2f}s  sha={r['file_sha'][:16]}  infected={r['infected']}", file=sys.stderr)
 
+    params = {
+        "length": args.length, "seed": args.seed, "dmp_mode": args.dmp_mode,
+        "papdata": papdata_path.name, "patterns": patterns_path.name,
+    }
     summary = {
         "label": args.label,
         "sim_root": str(sim_root),
-        "length_minutes": args.length,
-        "seed": args.seed,
-        "papdata": str(papdata_path),
-        "patterns": str(patterns_path),
-        "smoke": {"elapsed": smoke_elapsed, "sha": smoke_sha},
+        "params": params,
         "measured": {
-            "n": args.runs,
-            "min": min(timings),
-            "median": statistics.median(timings),
-            "max": max(timings),
-            "all": timings,
+            "n": args.runs, "min": min(timings),
+            "median": statistics.median(timings), "max": max(timings), "all": timings,
         },
         "hashes": hashes,
         "hashes_consistent": len(set(hashes)) == 1,
+        "infected": fingerprint.get("infected"),
     }
+
+    exit_code = 0
+
+    if args.write_golden:
+        golden = {"params": params, **fingerprint}
+        Path(args.write_golden).write_text(json.dumps(golden, indent=2))
+        print(f"[{args.label}] wrote golden -> {args.write_golden}", file=sys.stderr)
+        summary["golden_written"] = args.write_golden
+
+    if args.check_golden:
+        golden = json.loads(Path(args.check_golden).read_text())
+        if golden.get("params") != params:
+            print(f"[{args.label}] WARNING: params differ from golden "
+                  f"(golden={golden.get('params')} current={params})", file=sys.stderr)
+        diffs = []
+        for field in ("simdata_canon_sha", "patterns_canon_sha", "infected"):
+            want, got = golden.get(field), fingerprint.get(field)
+            if want != got:
+                diffs.append(f"{field}: golden={want} current={got}")
+        if diffs:
+            print(f"[{args.label}] GOLDEN DRIFT:", file=sys.stderr)
+            for d in diffs:
+                print(f"    {d}", file=sys.stderr)
+            exit_code = 1
+        else:
+            print(f"[{args.label}] golden OK (infected={fingerprint.get('infected')}, "
+                  f"simdata+patterns canonical match)", file=sys.stderr)
+        summary["golden_ok"] = not diffs
+
     print(json.dumps(summary, indent=2))
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Stage 0 of the planned struct-of-arrays (SoA) refactor: a regression guard so that representation-only changes can be **proven** to leave simulation output unchanged before we start moving agent state into arrays.

Adds `--write-golden` / `--check-golden` to `scripts/perf_bench.py`:
- Freezes a behavioral fingerprint: a **canonical content hash** of `simdata` + `patterns` (decompress → parse → sorted-compact JSON → sha) plus total infected count.
- Canonical hashing is **format-agnostic** — immune to serialization changes (orjson vs json, gzip level, key order), so it survives the orjson PR (#8) and trips only on a genuine change in simulation output. That's exactly the invariant the SoA stages must hold.
- `--check-golden` exits non-zero on drift with a field-level diff.

## Why this first
The SoA refactor moves agent attributes (`location`, `masked`, infection `state`, …) from Python objects into parallel numpy arrays. Each stage must produce **byte-identical** output to the prior one (it changes storage, not computation). This guard makes that checkable in CI/locally. The golden *values* will be frozen per-stage on the actual refactor base (post DMP #6 + orjson #8), not in this PR — this PR is the tooling only.

## Verified
- Identical re-run → `golden OK`, exit 0.
- Drifted fingerprint → `GOLDEN DRIFT` with field-level diff, exit 1.

## Note
The runner forces `random.seed(0)` when `randseed=False`, so the bench `--seed` only affects `np.random` (in-process DMP sampling), not the Python RNG. Golden reproducibility comes from that runner determinism — documented in the commit.

## Test plan
- [x] write golden (dmp off, 48h, seed 0) → re-check passes
- [x] corrupted golden → check fails (exit 1) with diff
- [ ] Reviewer: freeze the real golden on the SoA base when Stage 1 opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)