### PR TITLE
Serve simulation under gunicorn (fix concurrent-sim slowdown) + DMP_API_URL alias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,18 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Application code
 COPY . .
 
-# Default: run the simulation server (override in compose for DMP)
+# Default: run the simulation server (override in compose for DMP).
+#
+# Use gunicorn with multiple worker PROCESSES rather than the Flask dev server.
+# A simulation is CPU-bound Python, so threads share one GIL and concurrent
+# sims serialize onto a single core (each ~2x slower under load). Separate
+# worker processes let concurrent sims run on separate cores.
+#
+#   - WEB_CONCURRENCY sets the number of workers (override per host/core count
+#     in compose; defaults to 4 here).
+#   - --timeout 0 disables the worker timeout. Each POST /simulation/ streams
+#     Server-Sent Events for the full run duration, so a non-zero timeout would
+#     kill long-running sims mid-stream.
 EXPOSE 1870
-CMD ["python", "app.py"]
+ENV WEB_CONCURRENCY=4
+CMD ["gunicorn", "--worker-class", "sync", "--timeout", "0", "--bind", "0.0.0.0:1870", "app:app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ fuzzywuzzy==0.18.0
 geopandas==1.1.1
 gitdb==4.0.12
 GitPython==3.1.46
+gunicorn==23.0.0
 h11==0.16.0
 haversine==2.9.0
 idna==3.11

--- a/simulator/config.py
+++ b/simulator/config.py
@@ -6,7 +6,16 @@ import os
 
 # DMP API settings
 DMP_API = {
-    "base_url": os.environ.get("DMP_API_BASE_URL", "http://localhost:8000"),
+    # HTTP fallback target, used only when the in-process DMP is unavailable.
+    # Accept DMP_API_URL as an alias: the deploy compose sets DMP_API_URL, so
+    # without this alias base_url would silently default to localhost:8000 (where
+    # nothing listens inside the sim container) and the fallback would never reach
+    # the real dmp service.
+    "base_url": (
+        os.environ.get("DMP_API_BASE_URL")
+        or os.environ.get("DMP_API_URL")
+        or "http://localhost:8000"
+    ),
     "mode": os.environ.get("DMP_MODE", "auto"),
     "timeout_seconds": int(os.environ.get("DMP_API_TIMEOUT_SECONDS", "30")),
     # When true, resolve timelines via the in-process DMP (reads the local


### PR DESCRIPTION
## Why

Investigated a report that simulations feel ~2x slower on prod (covidmod.isi.jhu.edu) than localhost for the same Barnsdall zone (74002 / min-pop 5000 / greedy-weight, ~7000 people, 720h month-long run).

Measured findings:
- The simulator **compute is the same speed** on prod and local; the in-process DMP is confirmed working on both (`timeline_source_counts` = `{dmp: 24-26k, fallback: 0}` on every prod run — **not** the slow per-infection HTTP path).
- The ~2x appears under **concurrent load**. The Flask dev-server entrypoint (`app.run(threaded=True)`) runs CPU-bound sims on threads that share one GIL, so overlapping sims serialize. Localhost is single-user; prod is a shared multi-user host, so the contention shows there.

Reproduced directly: two concurrent 720h runs on the Flask server took **56s & 59s** each (vs ~31s solo).

## What

1. **gunicorn entrypoint** (`Dockerfile`, `requirements.txt`): run the sim server under gunicorn with multiple worker **processes** instead of the Flask dev server. CPU-bound sims now run on separate cores instead of serializing on one GIL.
   - `WEB_CONCURRENCY` controls worker count (default 4; override per host).
   - `--timeout 0` because each `/simulation/` request streams SSE for the full run duration — a non-zero timeout would kill long runs mid-stream.
2. **DMP env-var alias** (`simulator/config.py`): accept `DMP_API_URL` as an alias for `DMP_API_BASE_URL`. The deploy compose sets `DMP_API_URL`, so without this the HTTP-fallback base URL silently defaulted to `localhost:8000` (nothing listens there in the sim container) and could never reach the real `dmp` service if the in-process DMP ever became unavailable. In-process path is unaffected; this only repairs the fallback target. Backward-compatible (does not require any Deploy change).

## Verification

Ran the app under `gunicorn --worker-class sync --timeout 0` with `WEB_CONCURRENCY=2` locally:

| | Flask dev server (old) | gunicorn 2 workers (new) |
|---|---|---|
| Solo 720h | ~31-40s | 40s |
| **2 concurrent 720h** | **56s & 59s (~2x)** | **41s & 44s (~1x)** |

SSE progress streaming confirmed working through gunicorn; single-sim latency unchanged.

## Notes
- Single-sim latency is single-core-bound and does not change; this fixes throughput/latency **under concurrency**.
- The deploy-entrypoint test (`tests/test_deploy_entrypoints.py`) only asserts imports, so it is unaffected by the CMD change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)