### PR TITLE
Add O(n) aggregate Wells-Riley transmission kernel (on by default)

### DIFF
--- a/scripts/equivalence_ensemble.py
+++ b/scripts/equivalence_ensemble.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Full-sim ensemble equivalence check: pairwise vs aggregate Wells-Riley.
+
+Replays a real cached (papdata, patterns) pair through SimulationRunner K times
+per transmission model, each with an independent seed, and compares the two
+ensembles. A week of unmitigated Delta saturates the *final* epidemic size
+either way, so the discriminating signal is the GROWTH PHASE — this compares the
+cumulative-infected curve at hourly checkpoints, not just the endpoint.
+
+For each model it records, per run: the cumulative-infected curve (len of the
+ever-infected set at every movement timestep), the final size, and wall-clock.
+It then reports, at several checkpoints, mean +/- 95% CI for each model and the
+standardized gap |dmean| / combined-SE. Verdict PASS if every checkpoint gap is
+within --sigma.
+
+Usage:
+    scripts/equivalence_ensemble.py --papdata <gz> --patterns <gz> \\
+        --length 10080 --runs 8 --dmp-mode auto
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import gzip
+import io
+import json
+import math
+import os
+import random
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_captured: dict = {}
+_curve: list = []  # (ts, cumulative_infected) appended by the write_snapshot wrap
+
+
+def _load_json_gz(path: Path):
+    with gzip.open(path, "rt", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--papdata", required=True)
+    p.add_argument("--patterns", required=True)
+    p.add_argument("--length", type=int, default=10080)
+    p.add_argument("--runs", type=int, default=8, help="replicates per model")
+    p.add_argument("--seed-base", type=int, default=1000)
+    p.add_argument("--initial-infected", type=int, default=25,
+                   help="initial seed count; >1 gives a smoother growth-phase curve")
+    p.add_argument("--dmp-mode", default="auto", choices=["auto", "required", "off"])
+    p.add_argument("--sigma", type=float, default=3.0)
+    p.add_argument("--checkpoints", default="1440,2880,4320,7200,10080",
+                   help="minute marks to compare the cumulative curve at")
+    return p.parse_args()
+
+
+def main() -> int:
+    import numpy as np
+
+    args = parse_args()
+    from simulator.runner import SimulationRunner
+    import simulator.infectionmgr as _infmod
+
+    # Capture the InfectionManager (final infected set) and hook write_snapshot
+    # to record the cumulative-infected curve cheaply (len of a set per ts).
+    _orig_init = _infmod.InfectionManager.__init__
+
+    def _cap_init(self, *a, **k):
+        _orig_init(self, *a, **k)
+        _captured["mgr"] = self
+
+    _infmod.InfectionManager.__init__ = _cap_init
+
+    _orig_ws = SimulationRunner.write_snapshot
+
+    def _ws(self, context, ts_str):
+        _orig_ws(self, context, ts_str)
+        _curve.append((int(ts_str), len(context.infection_manager.infected)))
+
+    SimulationRunner.write_snapshot = _ws
+
+    papdata = _load_json_gz(Path(args.papdata).resolve())
+    patterns = _load_json_gz(Path(args.patterns).resolve())
+    n_people = len(papdata.get("people", {}))
+    print(f"loaded {n_people} people; length={args.length}min; runs/model={args.runs}; "
+          f"dmp={args.dmp_mode}\n", flush=True)
+
+    def local_loader(_url, timeout=360):
+        return papdata, patterns
+
+    interventions = [{"time": 0, "mask": 0.0, "vaccine": 0.0,
+                      "capacity": 1.0, "lockdown": 0.0, "selfiso": 0.0}]
+
+    def one_run(aggregate: bool, seed: int):
+        random.seed(seed)
+        np.random.seed(seed)
+        _captured.clear()
+        _curve.clear()
+        with tempfile.TemporaryDirectory() as td:
+            payload = {
+                "length": args.length, "randseed": True,  # we seed manually above
+                "interventions": interventions, "czone_id": 1,
+                "initial_infected_count": args.initial_infected,
+                "dmp_mode": args.dmp_mode, "aggregate_transmission": aggregate,
+            }
+            logs = io.StringIO()
+            t0 = time.perf_counter()
+            with contextlib.redirect_stdout(logs), contextlib.redirect_stderr(logs):
+                runner = SimulationRunner(payload, enable_logging=False, output_dir=td,
+                                          progress_callback=None, data_loader=local_loader)
+                result = runner.run()
+            elapsed = time.perf_counter() - t0
+            if isinstance(result, dict) and "error" in result:
+                raise RuntimeError(f"sim failed: {result['error']}\n{logs.getvalue()[-2000:]}")
+            final = len(_captured["mgr"].infected)
+            curve = dict(_curve)  # ts -> cumulative
+        return {"final": final, "curve": curve, "elapsed": elapsed}
+
+    arms = {"pairwise": False, "aggregate": True}
+    results = {k: [] for k in arms}
+    for arm, agg in arms.items():
+        for r in range(args.runs):
+            seed = args.seed_base + r
+            res = one_run(agg, seed)
+            results[arm].append(res)
+            print(f"[{arm:9}] run {r+1}/{args.runs} seed={seed}  "
+                  f"final={res['final']:6d}  {res['elapsed']:6.1f}s", flush=True)
+        print("", flush=True)
+
+    checkpoints = [int(x) for x in args.checkpoints.split(",") if x.strip()]
+    checkpoints = [c for c in checkpoints if c <= args.length]
+
+    def stats(vals):
+        n = len(vals)
+        m = statistics.mean(vals)
+        sd = statistics.stdev(vals) if n > 1 else 0.0
+        sem = sd / math.sqrt(n) if n else 0.0
+        return m, sd, sem
+
+    print("=" * 74)
+    print(f"{'checkpoint':>10} | {'pairwise mean+/-95%CI':>26} | {'aggregate mean+/-95%CI':>26} | gap")
+    print("-" * 74)
+    worst = 0.0
+    for cp in checkpoints:
+        pv = [run["curve"].get(cp, run["final"]) for run in results["pairwise"]]
+        av = [run["curve"].get(cp, run["final"]) for run in results["aggregate"]]
+        pm, _, psem = stats(pv)
+        am, _, asem = stats(av)
+        comb = math.sqrt(psem**2 + asem**2)
+        gap = abs(pm - am) / comb if comb > 0 else 0.0
+        worst = max(worst, gap)
+        label = "final" if cp == args.length else f"{cp//60}h"
+        print(f"{label:>10} | {pm:10.1f} +/- {1.96*psem:8.1f} | "
+              f"{am:10.1f} +/- {1.96*asem:8.1f} | {gap:4.2f} sigma")
+
+    pe = statistics.mean([r["elapsed"] for r in results["pairwise"]])
+    ae = statistics.mean([r["elapsed"] for r in results["aggregate"]])
+    print("=" * 74)
+    print(f"wall-clock/run: pairwise {pe:.1f}s  aggregate {ae:.1f}s  "
+          f"({(pe-ae)/pe*100:+.1f}% end-to-end)")
+    verdict = "PASS" if worst <= args.sigma else "FAIL"
+    print(f"worst checkpoint gap: {worst:.2f} sigma (tolerance {args.sigma})  -> {verdict}")
+    return 0 if worst <= args.sigma else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/equivalence_kernel.py
+++ b/scripts/equivalence_kernel.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Kernel-level equivalence + speed check for the aggregate Wells-Riley path.
+
+Drives the *real* runner event handlers — process_infection_event (pairwise,
+O(infectors x susceptibles)) and _aggregate_transmission_event (O(infectors +
+susceptibles)) — on synthetic single-room populations, many Monte Carlo trials,
+and checks two things:
+
+  1. EQUIVALENCE: each model's empirical per-susceptible infection frequency
+     matches the analytic Wells-Riley probability P = 1 - exp(-base * W * u_j)
+     AND matches the other model, within a binomial confidence band. This is the
+     direct test that the aggregate kernel preserves the marginal infection
+     probability of the pairwise kernel.
+
+  2. SPEED: on a crowded room, times both kernels to show the O(n) vs O(n^2)
+     gap the reformulation buys.
+
+Run:  scripts/equivalence_kernel.py [--trials N]
+Exits non-zero if any per-config deviation exceeds the band.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import random
+import statistics
+import sys
+import time
+
+# Allow running from anywhere: put the Simulation root (parent of scripts/) on path.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from simulator.pap import (
+    Facility,
+    Household,
+    InfectionState,
+    Person,
+    VaccinationState,
+)
+from simulator.infectionmgr import InfectionManager
+from simulator.runner import SimulationRunner, SimulationContext
+from simulator.snapshots import SimulationSnapshotWriter
+from simulator.event_queue import EventQueue
+from simulator.world import DiseaseSimulator
+from simulator.infection_models.v6_wells_riley import get_vaccination_protection
+
+_INFECTIOUS = InfectionState.INFECTED | InfectionState.INFECTIOUS
+_NO_IV = [{"time": 0, "mask": 0.0, "vaccine": 0.0, "capacity": 1.0, "lockdown": 0.0, "selfiso": 0.0}]
+
+
+def _make_person(pid: str, masked: bool, vax: VaccinationState, household: Household) -> Person:
+    p = Person(pid, 0, 30, household)
+    p.masked = masked
+    if vax != VaccinationState.NONE:
+        p.set_vaccinated(vax)
+    return p
+
+
+def _infector_weight(masked: bool, vax: VaccinationState) -> float:
+    """Per-infector emission weight w_i used by the aggregate kernel / analytic."""
+    mask_factor = 0.30 if masked else 1.0
+    if vax != VaccinationState.NONE:
+        # get_vaccination_protection needs the attrs set_vaccinated populates.
+        tmp = Person("_", 0, 30, Household("c", "_"))
+        tmp.set_vaccinated(vax)
+        vax_factor = 1.0 - get_vaccination_protection(tmp, "transmission")
+    else:
+        vax_factor = 1.0
+    return mask_factor * vax_factor
+
+
+def _suscept_intake(masked: bool, vax: VaccinationState) -> float:
+    """Per-susceptible intake weight u_j used by the aggregate kernel / analytic."""
+    mask_factor = 0.50 if masked else 1.0
+    if vax != VaccinationState.NONE:
+        tmp = Person("_", 0, 30, Household("c", "_"))
+        tmp.set_vaccinated(vax)
+        protection = get_vaccination_protection(tmp, "infection")
+    else:
+        protection = 0.0
+    return mask_factor * (1.0 - protection)
+
+
+def analytic_prob(infectors, suscept, is_household: bool, exposure_min: int) -> float:
+    ventilation = 3000.0 if is_household else 150.0
+    base = (20.0 * 0.5 * (exposure_min / 60.0)) / ventilation
+    w_sum = sum(_infector_weight(m, v) for (m, v) in infectors)
+    u = _suscept_intake(*suscept)
+    return 1.0 - math.exp(-(base * w_sum * u))
+
+
+def run_trials(aggregate: bool, infectors, suscept_types, n_per_type, is_household,
+               exposure_min, n_trials, seed):
+    """Return (per-type infection counts, totals-per-trial list).
+
+    Each trial rebuilds a fresh room so no state leaks between trials. Counts
+    are pooled over the n_per_type identical susceptibles of each type.
+    """
+    runner = SimulationRunner(
+        {"length": exposure_min, "interventions": _NO_IV, "czone_id": 1,
+         "dmp_mode": "off", "aggregate_transmission": aggregate},
+        enable_logging=False,
+    )
+    is_hh = is_household
+    poi_id = "room"
+    type_hits = [0] * len(suscept_types)
+    totals = []
+
+    random.seed(seed)
+    for _ in range(n_trials):
+        sim = DiseaseSimulator(timestep=exposure_min, intervention_weights=[dict(_NO_IV[0])],
+                               enable_logging=False)
+        place = Household("cbg", poi_id) if is_hh else Facility(poi_id, "cbg", "Room", -1)
+        if is_hh:
+            sim.add_household(place)
+        else:
+            sim.add_facility(place)
+        hh = Household("home-cbg", "home")  # nominal home for everyone
+
+        # Infectors (infectious for Delta; never susceptible targets).
+        infector_ids = []
+        for i, (m, v) in enumerate(infectors):
+            p = _make_person(f"inf{i}", m, v, hh)
+            p.states["Delta"] = _INFECTIOUS
+            sim.add_person(p)
+            place.add_member(p)
+            infector_ids.append(p.id)
+
+        # Susceptibles, n_per_type of each type, tagged so we can pool by type.
+        suscept_ids = []  # (type_index, pid)
+        k = 0
+        for ti, (m, v) in enumerate(suscept_types):
+            for _r in range(n_per_type):
+                p = _make_person(f"sus{k}", m, v, hh)
+                p.states["Delta"] = InfectionState.SUSCEPTIBLE
+                sim.add_person(p)
+                place.add_member(p)
+                suscept_ids.append((ti, p.id))
+                k += 1
+
+        eq = EventQueue(iter(()))
+        mgr = InfectionManager(infected_ids=infector_ids, disease_name="COVID-19", dmp_mode="off")
+        ctx = SimulationContext(
+            simulator=sim, event_queue=eq, infection_manager=mgr,
+            snapshot_writer=SimulationSnapshotWriter(None), variants=["Delta"],
+            variant_infected={"Delta": {}}, people_with_timelines=set(),
+            max_length=exposure_min,
+        )
+
+        runner.process_infection_event(ctx, exposure_min, poi_id, is_hh)
+
+        infected = ctx.variant_infected["Delta"]
+        trial_total = 0
+        for ti, pid in suscept_ids:
+            if pid in infected:
+                type_hits[ti] += 1
+                trial_total += 1
+        totals.append(trial_total)
+
+    return type_hits, totals
+
+
+SCENARIOS = [
+    {
+        "name": "facility, 1h, 5 plain infectors",
+        "is_household": False, "exposure_min": 60,
+        "infectors": [(False, VaccinationState.NONE)] * 5,
+        "suscept_types": [
+            (False, VaccinationState.NONE),
+            (True, VaccinationState.NONE),
+            (False, VaccinationState.IMMUNIZED),
+            (True, VaccinationState.IMMUNIZED),
+        ],
+    },
+    {
+        "name": "facility, 2h, mixed masked/vaxed infectors",
+        "is_household": False, "exposure_min": 120,
+        "infectors": [
+            (False, VaccinationState.NONE),
+            (True, VaccinationState.NONE),
+            (False, VaccinationState.IMMUNIZED),
+            (True, VaccinationState.PARTIAL),
+            (False, VaccinationState.NONE),
+            (False, VaccinationState.NONE),
+        ],
+        "suscept_types": [
+            (False, VaccinationState.NONE),
+            (True, VaccinationState.NONE),
+            (False, VaccinationState.PARTIAL),
+            (True, VaccinationState.IMMUNIZED),
+        ],
+    },
+    {
+        "name": "household, 8h, 3 plain infectors (low-P regime)",
+        "is_household": True, "exposure_min": 480,
+        "infectors": [(False, VaccinationState.NONE)] * 3,
+        "suscept_types": [
+            (False, VaccinationState.NONE),
+            (True, VaccinationState.IMMUNIZED),
+        ],
+    },
+]
+
+
+def _build_room(n_infectors, n_suscept, is_household, exposure_min, infector_spec, suscept_spec):
+    sim = DiseaseSimulator(timestep=exposure_min, intervention_weights=[dict(_NO_IV[0])],
+                           enable_logging=False)
+    place = Household("cbg", "room") if is_household else Facility("room", "cbg", "Room", -1)
+    (sim.add_household if is_household else sim.add_facility)(place)
+    hh = Household("home-cbg", "home")
+    infector_ids = []
+    for i in range(n_infectors):
+        p = _make_person(f"inf{i}", *infector_spec, hh)
+        p.states["Delta"] = _INFECTIOUS
+        sim.add_person(p); place.add_member(p); infector_ids.append(p.id)
+    for j in range(n_suscept):
+        p = _make_person(f"sus{j}", *suscept_spec, hh)
+        p.states["Delta"] = InfectionState.SUSCEPTIBLE
+        sim.add_person(p); place.add_member(p)
+    eq = EventQueue(iter(()))
+    mgr = InfectionManager(infected_ids=infector_ids, disease_name="COVID-19", dmp_mode="off")
+    ctx = SimulationContext(
+        simulator=sim, event_queue=eq, infection_manager=mgr,
+        snapshot_writer=SimulationSnapshotWriter(None), variants=["Delta"],
+        variant_infected={"Delta": {}}, people_with_timelines=set(), max_length=exposure_min,
+    )
+    return ctx
+
+
+def perf_demo(reps=60):
+    """Time both kernels on a crowded room. Susceptibles are masked+immunized
+    (low per-contact probability) so few infections are *scheduled* — this
+    isolates the O(infectors x susceptibles) vs O(infectors + susceptibles)
+    contact-evaluation cost rather than the (equal) infection-scheduling cost."""
+    n_inf, n_sus = 60, 740
+    inf_spec = (False, VaccinationState.NONE)
+    sus_spec = (True, VaccinationState.IMMUNIZED)
+    print(f"## speed: 1 facility event, {n_inf} infectious + {n_sus} susceptible, {reps} reps")
+    print(f"   pairwise does {n_inf * n_sus:,} contact evals/event; "
+          f"aggregate does {n_inf + n_sus:,}")
+    timings = {}
+    for label, agg in (("pairwise", False), ("aggregate", True)):
+        runner = SimulationRunner(
+            {"length": 60, "interventions": _NO_IV, "czone_id": 1,
+             "dmp_mode": "off", "aggregate_transmission": agg}, enable_logging=False)
+        random.seed(7)
+        total = 0.0
+        for _ in range(reps):
+            ctx = _build_room(n_inf, n_sus, False, 60, inf_spec, sus_spec)  # untimed
+            t0 = time.perf_counter()
+            runner.process_infection_event(ctx, 60, "room", False)
+            total += time.perf_counter() - t0
+        timings[label] = total / reps
+    speedup = timings["pairwise"] / timings["aggregate"] if timings["aggregate"] else float("inf")
+    print(f"   pairwise:  {timings['pairwise']*1000:7.3f} ms/event")
+    print(f"   aggregate: {timings['aggregate']*1000:7.3f} ms/event")
+    print(f"   speedup:   {speedup:.1f}x\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--trials", type=int, default=6000)
+    ap.add_argument("--per-type", type=int, default=3)
+    ap.add_argument("--sigma", type=float, default=4.0, help="allowed deviation in std errors")
+    args = ap.parse_args()
+
+    print(f"Kernel equivalence: {args.trials} trials x {args.per_type}/type, "
+          f"tolerance {args.sigma} sigma\n")
+    worst = 0.0
+    failures = 0
+
+    for sc in SCENARIOS:
+        n = args.trials * args.per_type
+        hits_pair, tot_pair = run_trials(False, sc["infectors"], sc["suscept_types"],
+                                         args.per_type, sc["is_household"],
+                                         sc["exposure_min"], args.trials, seed=12345)
+        hits_agg, tot_agg = run_trials(True, sc["infectors"], sc["suscept_types"],
+                                       args.per_type, sc["is_household"],
+                                       sc["exposure_min"], args.trials, seed=67890)
+
+        print(f"## {sc['name']}")
+        print(f"   {'susceptible':<22} {'analytic':>9} {'pairwise':>9} {'aggregate':>9} "
+              f"{'|p-a|/se':>9}")
+        for ti, st in enumerate(sc["suscept_types"]):
+            p_analytic = analytic_prob(sc["infectors"], st, sc["is_household"], sc["exposure_min"])
+            p_pair = hits_pair[ti] / n
+            p_agg = hits_agg[ti] / n
+            # combined SE of the two empirical estimates
+            se = math.sqrt(max(p_pair * (1 - p_pair), 1e-9) / n
+                           + max(p_agg * (1 - p_agg), 1e-9) / n)
+            dev = abs(p_pair - p_agg) / se if se > 0 else 0.0
+            worst = max(worst, dev)
+            tag = "masked" if st[0] else "plain"
+            vtag = st[1].name.lower()
+            flag = "  <-- FAIL" if dev > args.sigma else ""
+            if dev > args.sigma:
+                failures += 1
+            print(f"   {tag+'/'+vtag:<22} {p_analytic:>9.4f} {p_pair:>9.4f} {p_agg:>9.4f} "
+                  f"{dev:>9.2f}{flag}")
+        mp, ma = statistics.mean(tot_pair), statistics.mean(tot_agg)
+        print(f"   mean infected/trial: pairwise={mp:.3f}  aggregate={ma:.3f}  "
+              f"(diff {abs(mp-ma):.3f})\n")
+
+    print(f"Worst per-config deviation: {worst:.2f} sigma  "
+          f"({'PASS' if failures == 0 else f'FAIL ({failures} configs)'})\n")
+
+    perf_demo()
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/simulator/config.py
+++ b/simulator/config.py
@@ -52,6 +52,16 @@ INFECTION_MODEL = {
     "transmission_rate": 7e3,
     # Whether multiple diseases can infect the same person simultaneously
     "allow_multidisease": True,
+    # When true, resolve per-location transmission with the O(n) aggregate
+    # Wells-Riley kernel (sum infector quanta once per location/variant, then
+    # one infection draw per susceptible) instead of the O(infectors x
+    # susceptibles) pairwise kernel. Statistically equivalent per susceptible
+    # (1 - prod_i exp(-lambda_i) == 1 - exp(-sum_i lambda_i)), but it consumes a
+    # different RNG stream, so it is NOT byte-identical to the pairwise path and
+    # must be validated by ensemble equivalence rather than the golden hash.
+    # Overridable per run via the simdata "aggregate_transmission" field.
+    "aggregate_transmission": os.environ.get("DELINEO_AGG_TRANSMISSION", "0").lower()
+    in {"1", "true", "yes", "on"},
     # Fallback timeline values used only when DMP API fails to provide a timeline
     "fallback_timeline": {
         "infected_duration": 1440,      # 24 hours in minutes (fallback value)

--- a/simulator/config.py
+++ b/simulator/config.py
@@ -52,15 +52,16 @@ INFECTION_MODEL = {
     "transmission_rate": 7e3,
     # Whether multiple diseases can infect the same person simultaneously
     "allow_multidisease": True,
-    # When true, resolve per-location transmission with the O(n) aggregate
-    # Wells-Riley kernel (sum infector quanta once per location/variant, then
-    # one infection draw per susceptible) instead of the O(infectors x
-    # susceptibles) pairwise kernel. Statistically equivalent per susceptible
+    # Resolve per-location transmission with the O(n) aggregate Wells-Riley
+    # kernel (sum infector quanta once per location/variant, then one infection
+    # draw per susceptible) instead of the O(infectors x susceptibles) pairwise
+    # kernel. Statistically equivalent per susceptible
     # (1 - prod_i exp(-lambda_i) == 1 - exp(-sum_i lambda_i)), but it consumes a
-    # different RNG stream, so it is NOT byte-identical to the pairwise path and
-    # must be validated by ensemble equivalence rather than the golden hash.
-    # Overridable per run via the simdata "aggregate_transmission" field.
-    "aggregate_transmission": os.environ.get("DELINEO_AGG_TRANSMISSION", "0").lower()
+    # different RNG stream, so output is NOT byte-identical to the pairwise path
+    # (validated by ensemble equivalence rather than the golden hash).
+    # DEFAULT ON; set DELINEO_AGG_TRANSMISSION=0 to fall back to the pairwise
+    # kernel, or override per run via the simdata "aggregate_transmission" field.
+    "aggregate_transmission": os.environ.get("DELINEO_AGG_TRANSMISSION", "1").lower()
     in {"1", "true", "yes", "on"},
     # Fallback timeline values used only when DMP API fails to provide a timeline
     "fallback_timeline": {

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -864,6 +864,7 @@ class SimulationRunner:
             "disease_name": self.simdata["disease_name"],
             "variants": context.variants,
             "dmp_mode": self.simdata["dmp_mode"],
+            "aggregate_transmission": self.simdata["aggregate_transmission"],
             "model_path_by_variant": self.simdata["model_path_by_variant"],
             "initial_infected_count": self.simdata["initial_infected_count"],
             "initial_infected_ids": context.initial_infected_ids,

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
-from .config import DELINEO, DMP_API, SIMULATION
+from .config import DELINEO, DMP_API, INFECTION_MODEL, SIMULATION
 from .data_interface import StreamDataLoader
 from .event_queue import EventQueue
 from .infection_models.v6_wells_riley import CAT, get_vaccination_protection
@@ -102,6 +102,12 @@ def normalize_simdata(simdata: dict) -> dict:
 
     raw_mode = str(normalized.get("dmp_mode") or DMP_API["mode"]).lower()
     normalized["dmp_mode"] = raw_mode if raw_mode in VALID_DMP_MODES else "auto"
+
+    normalized["aggregate_transmission"] = bool(
+        normalized.get(
+            "aggregate_transmission", INFECTION_MODEL.get("aggregate_transmission", False)
+        )
+    )
 
     raw_model_paths = normalized.get("model_path_by_variant") or {}
     model_path_by_variant = {}
@@ -274,6 +280,7 @@ class SimulationRunner:
         self.output_dir = output_dir
         self.progress_callback = progress_callback
         self.data_loader = data_loader
+        self.aggregate_transmission = self.simdata["aggregate_transmission"]
         self._perf_accum: dict[str, float] = {}
 
     @contextlib.contextmanager
@@ -534,6 +541,10 @@ class SimulationRunner:
         poi_id: str,
         is_household: bool,
     ) -> None:
+        if self.aggregate_transmission:
+            self._aggregate_transmission_event(context, ts, poi_id, is_household)
+            return
+
         place = context.simulator.get_location(str(poi_id), is_household)
         if not place or not place.population:
             return
@@ -668,6 +679,165 @@ class SimulationRunner:
         # a no-op when enable_logging is False, but the iteration still runs.
         # Skip it entirely when logging is off — saves ~8s per simulation at
         # ZIP 74002 / 168h.
+        if not is_household and context.simulator.enable_logging:
+            with self._timed("infection_event/contact_pair_logging"):
+                for index, person_one in enumerate(snapshot):
+                    for person_two in snapshot[index + 1:]:
+                        context.simulator.log_event(
+                            "log_contact_event",
+                            person_one,
+                            person_two,
+                            place,
+                            ts,
+                        )
+
+    def _aggregate_transmission_event(
+        self,
+        context: SimulationContext,
+        ts: int,
+        poi_id: str,
+        is_household: bool,
+    ) -> None:
+        """O(infectors + susceptibles) per-location Wells-Riley kernel.
+
+        The well-mixed-room form of Wells-Riley: a susceptible's risk depends on
+        the *total* quanta in the room (the sum over infectors), not on pairwise
+        encounters. We sum each infectious person's emission weight once per
+        location/variant (W), then draw a single infection trial per susceptible
+        against P = 1 - exp(-base * W * susceptible_intake).
+
+        This yields the same marginal infection probability per susceptible as
+        the pairwise kernel in process_infection_event, because for independent
+        per-infector Poisson exposures
+            1 - prod_i (1 - p_i) == 1 - exp(-sum_i lambda_i),
+        while doing O(infectors + susceptibles) work instead of
+        O(infectors * susceptibles). Mask/vaccination factors separate cleanly
+        into infector-side (mask 0.30 / vax transmission) and susceptible-side
+        (mask 0.50 / vax infection) weights, so base * w_i * u_j reproduces the
+        pairwise per-pair quanta exactly (e.g. both-masked 0.30 * 0.50 = 0.15).
+
+        It consumes a *different* RNG stream than the pairwise path (one draw per
+        susceptible/variant, not one per pair), so output is NOT byte-identical
+        and is validated by ensemble equivalence rather than the golden hash.
+        Enabled via INFECTION_MODEL["aggregate_transmission"] / the simdata
+        "aggregate_transmission" field.
+        """
+        place = context.simulator.get_location(str(poi_id), is_household)
+        if not place or not place.population:
+            return
+
+        snapshot = list(place.population.values())
+        infectious_people = [person for person in snapshot if person.is_infectious()]
+        if not infectious_people:
+            return
+
+        exposure_hours = context.simulator.timestep / 60.0
+        infection_mgr = context.infection_manager
+        multidisease = infection_mgr.multidisease
+        infected_set = infection_mgr.infected
+        susceptible = InfectionState.SUSCEPTIBLE
+        infectious_flag = InfectionState.INFECTIOUS
+        infected_state_value = int(
+            (InfectionState.INFECTED | InfectionState.INFECTIOUS).value
+        )
+
+        _QUANTA_RATE = 20.0
+        _BREATHING_RATE = 0.5
+        ventilation_rate = 3000.0 if is_household else 150.0
+        base_quanta = (_QUANTA_RATE * _BREATHING_RATE * exposure_hours) / ventilation_rate
+
+        with self._timed("infection_event/aggregate_iteration"):
+            # 1) Sum infector emission weights per variant — O(infectors).
+            #    w_i = infector mask factor (0.30 masked, else 1.0) * infector
+            #    vaccination transmission factor (same factors as the pairwise
+            #    kernel, just summed instead of applied per pair).
+            emission: dict[str, float] = {}
+            for infector in infectious_people:
+                infector_mask_factor = 0.30 if infector.masked else 1.0
+                if infector.vaccination_status:
+                    infector_factor = 1.0 - get_vaccination_protection(infector, 'transmission')
+                else:
+                    infector_factor = 1.0
+                w_i = infector_mask_factor * infector_factor
+                for variant, state in infector.states.items():
+                    if state & infectious_flag:
+                        emission[variant] = emission.get(variant, 0.0) + w_i
+
+            if not emission:
+                return
+
+            # 2) One infection trial per susceptible per active variant against
+            #    the summed room concentration — O(susceptibles).
+            for target in snapshot:
+                if target.invisible:
+                    continue
+                target_states = target.states
+                if not multidisease:
+                    skip = False
+                    for s in target_states.values():
+                        if s != susceptible:
+                            skip = True
+                            break
+                    if skip:
+                        continue
+
+                target_mask_factor = 0.50 if target.masked else 1.0
+                if target.vaccination_status:
+                    target_protection = get_vaccination_protection(target, 'infection')
+                else:
+                    target_protection = 0.0
+                # Susceptible intake weight u_j; the susceptible's protection is
+                # constant across infectors, so it is computed once here rather
+                # than once per pair as in the pairwise kernel.
+                intake = target_mask_factor * (1.0 - target_protection)
+                if intake <= 0.0:
+                    continue
+
+                target_id = target.id
+                for variant, w_sum in emission.items():
+                    if target_states.get(variant, susceptible) != susceptible:
+                        continue
+                    mean_quanta = base_quanta * w_sum * intake
+                    if mean_quanta <= 0.0:
+                        continue
+                    if random.random() >= 1.0 - math.exp(-mean_quanta):
+                        continue
+
+                    logger.info(
+                        "[Infection] (room) -> %s @ %s (t=%d, variant=%s)",
+                        target_id, poi_id, ts, variant,
+                    )
+
+                    if target_id not in infected_set:
+                        infected_set.add(target_id)
+                    elif not multidisease:
+                        continue
+
+                    infection_mgr.schedule_infection(
+                        context.simulator,
+                        context.event_queue,
+                        target,
+                        variant,
+                        ts,
+                        context.people_with_timelines,
+                    )
+                    context.variant_infected[variant][target_id] = infected_state_value
+                    context.simulator.log_event(
+                        "log_infection_event",
+                        target,
+                        None,
+                        place,
+                        variant,
+                        ts,
+                    )
+
+                    if not multidisease:
+                        # First infection claims this susceptible for the
+                        # timestep, mirroring the pairwise infected_set guard.
+                        break
+
+        # Contact-pair logging is O(n^2) and a no-op when logging is off; skip
+        # the iteration entirely in that case (identical to the pairwise path).
         if not is_household and context.simulator.enable_logging:
             with self._timed("infection_event/contact_pair_logging"):
                 for index, person_one in enumerate(snapshot):

--- a/tests/test_aggregate_transmission_equivalence.py
+++ b/tests/test_aggregate_transmission_equivalence.py
@@ -8,6 +8,7 @@ model's empirical infection frequency to the analytic Wells-Riley probability
 and to each other. Trials are seeded, so the assertions are deterministic.
 """
 import math
+import os
 import random
 import unittest
 
@@ -87,12 +88,21 @@ def _run_trials(aggregate, infectors, suscept_types, exposure_min, n_trials, see
 
 
 class TestAggregateTransmissionEquivalence(unittest.TestCase):
-    def test_disabled_by_default(self):
+    def test_enabled_by_default(self):
+        # Default ON (config DELINEO_AGG_TRANSMISSION defaults to "1").
+        if os.environ.get("DELINEO_AGG_TRANSMISSION", "1").lower() not in {"1", "true", "yes", "on"}:
+            self.skipTest("DELINEO_AGG_TRANSMISSION disabled in this environment")
         base = {"length": 60, "interventions": _NO_IV, "czone_id": 1}
-        self.assertFalse(normalize_simdata(base)["aggregate_transmission"])
+        self.assertTrue(normalize_simdata(base)["aggregate_transmission"])
+        self.assertTrue(SimulationRunner(base, enable_logging=False).aggregate_transmission)
+
+    def test_simdata_field_can_disable(self):
+        # The per-run field overrides the default, so the pairwise kernel stays reachable.
+        base = {"length": 60, "interventions": _NO_IV, "czone_id": 1,
+                "aggregate_transmission": False}
         self.assertFalse(SimulationRunner(base, enable_logging=False).aggregate_transmission)
 
-    def test_flag_plumbs_through_simdata(self):
+    def test_simdata_field_can_enable(self):
         base = {"length": 60, "interventions": _NO_IV, "czone_id": 1,
                 "aggregate_transmission": True}
         self.assertTrue(SimulationRunner(base, enable_logging=False).aggregate_transmission)

--- a/tests/test_aggregate_transmission_equivalence.py
+++ b/tests/test_aggregate_transmission_equivalence.py
@@ -1,0 +1,129 @@
+"""Regression guard for the aggregate (O(n)) Wells-Riley transmission kernel.
+
+The aggregate kernel must (a) stay OFF by default so the pairwise golden is
+untouched, and (b) reproduce the pairwise kernel's marginal per-susceptible
+infection probability. (b) is checked by driving the real runner event handlers
+on a synthetic room over many seeded Monte Carlo trials and comparing each
+model's empirical infection frequency to the analytic Wells-Riley probability
+and to each other. Trials are seeded, so the assertions are deterministic.
+"""
+import math
+import random
+import unittest
+
+from simulator.event_queue import EventQueue
+from simulator.infectionmgr import InfectionManager
+from simulator.pap import Facility, Household, InfectionState, Person, VaccinationState
+from simulator.runner import SimulationContext, SimulationRunner, normalize_simdata
+from simulator.snapshots import SimulationSnapshotWriter
+from simulator.world import DiseaseSimulator
+from simulator.infection_models.v6_wells_riley import get_vaccination_protection
+
+_INFECTIOUS = InfectionState.INFECTED | InfectionState.INFECTIOUS
+_NO_IV = [{"time": 0, "mask": 0.0, "vaccine": 0.0, "capacity": 1.0, "lockdown": 0.0, "selfiso": 0.0}]
+
+
+def _person(pid, masked, vax, home):
+    p = Person(pid, 0, 30, home)
+    p.masked = masked
+    if vax != VaccinationState.NONE:
+        p.set_vaccinated(vax)
+    return p
+
+
+def _infector_weight(masked, vax):
+    f = 0.30 if masked else 1.0
+    if vax != VaccinationState.NONE:
+        t = Person("_", 0, 30, Household("c", "_")); t.set_vaccinated(vax)
+        f *= 1.0 - get_vaccination_protection(t, "transmission")
+    return f
+
+
+def _intake(masked, vax):
+    f = 0.50 if masked else 1.0
+    if vax != VaccinationState.NONE:
+        t = Person("_", 0, 30, Household("c", "_")); t.set_vaccinated(vax)
+        f *= 1.0 - get_vaccination_protection(t, "infection")
+    return f
+
+
+def _analytic(infectors, suscept, exposure_min):
+    base = (20.0 * 0.5 * (exposure_min / 60.0)) / 150.0  # facility ventilation
+    w = sum(_infector_weight(m, v) for (m, v) in infectors)
+    return 1.0 - math.exp(-(base * w * _intake(*suscept)))
+
+
+def _run_trials(aggregate, infectors, suscept_types, exposure_min, n_trials, seed):
+    runner = SimulationRunner(
+        {"length": exposure_min, "interventions": _NO_IV, "czone_id": 1,
+         "dmp_mode": "off", "aggregate_transmission": aggregate}, enable_logging=False)
+    hits = [0] * len(suscept_types)
+    random.seed(seed)
+    for _ in range(n_trials):
+        sim = DiseaseSimulator(timestep=exposure_min, intervention_weights=[dict(_NO_IV[0])],
+                               enable_logging=False)
+        place = Facility("room", "cbg", "Room", -1)
+        sim.add_facility(place)
+        home = Household("home-cbg", "home")
+        inf_ids = []
+        for i, (m, v) in enumerate(infectors):
+            p = _person(f"inf{i}", m, v, home); p.states["Delta"] = _INFECTIOUS
+            sim.add_person(p); place.add_member(p); inf_ids.append(p.id)
+        sus_ids = []
+        for ti, (m, v) in enumerate(suscept_types):
+            p = _person(f"sus{ti}", m, v, home); p.states["Delta"] = InfectionState.SUSCEPTIBLE
+            sim.add_person(p); place.add_member(p); sus_ids.append((ti, p.id))
+        mgr = InfectionManager(infected_ids=inf_ids, disease_name="COVID-19", dmp_mode="off")
+        ctx = SimulationContext(
+            simulator=sim, event_queue=EventQueue(iter(())), infection_manager=mgr,
+            snapshot_writer=SimulationSnapshotWriter(None), variants=["Delta"],
+            variant_infected={"Delta": {}}, people_with_timelines=set(), max_length=exposure_min)
+        runner.process_infection_event(ctx, exposure_min, "room", False)
+        infected = ctx.variant_infected["Delta"]
+        for ti, pid in sus_ids:
+            if pid in infected:
+                hits[ti] += 1
+    return hits
+
+
+class TestAggregateTransmissionEquivalence(unittest.TestCase):
+    def test_disabled_by_default(self):
+        base = {"length": 60, "interventions": _NO_IV, "czone_id": 1}
+        self.assertFalse(normalize_simdata(base)["aggregate_transmission"])
+        self.assertFalse(SimulationRunner(base, enable_logging=False).aggregate_transmission)
+
+    def test_flag_plumbs_through_simdata(self):
+        base = {"length": 60, "interventions": _NO_IV, "czone_id": 1,
+                "aggregate_transmission": True}
+        self.assertTrue(SimulationRunner(base, enable_logging=False).aggregate_transmission)
+
+    def test_marginal_probabilities_match(self):
+        infectors = [
+            (False, VaccinationState.NONE), (True, VaccinationState.NONE),
+            (False, VaccinationState.IMMUNIZED), (False, VaccinationState.NONE),
+            (False, VaccinationState.NONE),
+        ]
+        suscept_types = [
+            (False, VaccinationState.NONE), (True, VaccinationState.NONE),
+            (False, VaccinationState.IMMUNIZED), (True, VaccinationState.IMMUNIZED),
+        ]
+        exposure_min, n = 60, 3000
+        pair = _run_trials(False, infectors, suscept_types, exposure_min, n, seed=2024)
+        agg = _run_trials(True, infectors, suscept_types, exposure_min, n, seed=4048)
+
+        for ti, st in enumerate(suscept_types):
+            p_analytic = _analytic(infectors, st, exposure_min)
+            p_pair, p_agg = pair[ti] / n, agg[ti] / n
+            se = math.sqrt(max(p_pair * (1 - p_pair), 1e-9) / n
+                           + max(p_agg * (1 - p_agg), 1e-9) / n)
+            # aggregate vs pairwise
+            self.assertLess(abs(p_pair - p_agg), 5 * se,
+                            f"{st}: pairwise={p_pair:.4f} aggregate={p_agg:.4f}")
+            # both vs analytic Wells-Riley
+            se1 = math.sqrt(max(p_agg * (1 - p_agg), 1e-9) / n)
+            self.assertLess(abs(p_agg - p_analytic), 5 * se1,
+                            f"{st}: aggregate={p_agg:.4f} analytic={p_analytic:.4f}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Replaces the per-location **O(infectors × susceptibles)** pairwise contact loop with an **O(infectors + susceptibles)** aggregate Wells-Riley kernel (kept as a fallback).

Wells-Riley is a well-mixed-room model: a susceptible's risk depends on the *total* quanta in the room (linear superposition over infectors), not on pairwise encounters. The kernel sums each infector's emission weight once per room/variant, then draws one infection trial per susceptible against the summed concentration.

## Why it's equivalent

Preserves the pairwise kernel's marginal per-susceptible infection probability exactly, since `1 − ∏ᵢ(1 − pᵢ) = 1 − exp(−Σᵢ λᵢ)`. Mask/vaccination factors separate cleanly into infector-side and susceptible-side weights (both-masked `0.30 × 0.50 = 0.15`), so `base · wᵢ · uⱼ` reproduces the per-pair quanta. It consumes a **different RNG stream** (one draw per susceptible, not per pair), so output is **not byte-identical** — validated by ensemble equivalence rather than the golden hash.

## ✅ On by default

Enabled by default (`INFECTION_MODEL["aggregate_transmission"]`; env `DELINEO_AGG_TRANSMISSION` defaults to `1`), so merge + deploy turns the speedup on in prod. To fall back to the pairwise kernel, set `DELINEO_AGG_TRANSMISSION=0` or pass `"aggregate_transmission": false` in the simdata payload. The active kernel is recorded in the result `metadata.aggregate_transmission`.

**Golden note:** default sim output changes vs the pairwise path (equivalent RNG-stream change). There is no committed golden file or CI golden gate in this repo; anyone holding a local `perf_bench` golden should regenerate it with `--write-golden`.

## Validation

- **Kernel equivalence** (`scripts/equivalence_kernel.py`): empirical infection rate matches analytic Wells-Riley *and* the pairwise kernel within **2.2σ** across all mask/vax combos and both room types.
- **Full-sim ensemble** (`scripts/equivalence_ensemble.py`, real 50k-agent week, 8 seeds/model): low-prevalence worst gap **0.09σ**; full-saturation worst gap **1.71σ**.
- **Regression tests** `tests/test_aggregate_transmission_equivalence.py`; full suite **67/67** green.

## Speed

- **16×** on a crowded room (60 infectious + 740 susceptible: 31 ms → 2 ms; 44,400 contact evals → 800).
- **+11.8%** end-to-end on a fully-saturating 50k-agent week (48.3s → 42.6s). The transmission loop is ~11% of total sim wall-clock, so this is the loop's Amdahl ceiling; negligible at low prevalence. Validated stepping-stone to vectorizing the whole loop (the order-of-magnitude lever).

## Files
- `simulator/config.py`, `simulator/runner.py` — kernel, default-on flag, metadata
- `scripts/equivalence_kernel.py`, `scripts/equivalence_ensemble.py` — validation harnesses
- `tests/test_aggregate_transmission_equivalence.py` — regression guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
