### PR TITLE
Hotfix: GET / returns 500 on every request (run_simulator missing simdata)

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,7 +2,6 @@ from flask import Flask, request, jsonify, Response, stream_with_context
 from flask_cors import CORS, cross_origin
 from jsonschema import validate
 from werkzeug.exceptions import BadRequest
-from simulator import simulate
 from simulator.jobs import start_simulation_job, stream_sse_messages
 from simulator.config import SERVER
 import os
@@ -99,10 +98,9 @@ def run_simulation_endpoint():
 @cross_origin()
 def run_main():
     """
-    Basic simulation endpoint for testing.
+    Health/status endpoint. The actual simulation entrypoint is POST /simulation/.
     """
-    # Use default values from config
-    return simulate.run_simulator()
+    return jsonify({"status": "ok", "service": "delineo-simulation"})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

`run_main()` (the `GET /` route) calls `simulate.run_simulator()` with no arguments, but `run_simulator(simdata, ...)` requires a `simdata` positional argument. So **every** `GET /` request 500s with:

```
TypeError: run_simulator() missing 1 required positional argument: 'simdata'
```

Health-checkers, uptime monitors, and browsers all hit `/`, so this spams the logs continuously. Confirmed present on `main` (prod).

## Fix

Make `GET /` a lightweight health/status endpoint:

```python
return jsonify({"status": "ok", "service": "delineo-simulation"})
```

The real simulation entrypoint, `POST /simulation/`, is unchanged. Also drops the now-unused `from simulator import simulate` import.

## Verification

- `curl localhost:1870/` on the old code → **500**; with this fix → **200** `{"service":"delineo-simulation","status":"ok"}`.
- `python -m pytest tests/` → all pre-existing passes still green (the 2 unrelated `test_state_machine_apptest.py` failures pre-date this change and are independent of `server.py`).
- Scope: 1 file, +2/-4. No behavior change to the simulation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)