### PR TITLE
Vectorized SoA engine (default-on) + binary patterns + per-place dot counts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -78,3 +78,4 @@ waitress==3.0.2
 wcwidth==0.2.14
 Werkzeug==3.1.3
 xyzservices==2025.4.0
+zstandard==0.25.0

--- a/scripts/transcode_patterns.py
+++ b/scripts/transcode_patterns.py
@@ -1,0 +1,49 @@
+"""Transcode a legacy JSON patterns blob into the DLNOPAT binary format.
+
+Reference for the Algorithms producer and a way to convert existing fixtures /
+cached patterns for testing. Reads papdata to enumerate the person + location id
+spaces (the binary format ships these tables in its header).
+
+Usage:
+    python scripts/transcode_patterns.py PAPDATA.json[.gz] PATTERNS.json[.gz] OUT.bin [--level 3]
+"""
+import argparse
+import gzip
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from simulator.patterns_codec import build_arrays_from_legacy, encode_patterns_binary
+
+
+def _load_json(path: str) -> dict:
+    opener = gzip.open if path.endswith(".gz") else open
+    with opener(path, "rb") as fh:
+        return json.loads(fh.read())
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("papdata")
+    ap.add_argument("patterns")
+    ap.add_argument("out")
+    ap.add_argument("--level", type=int, default=3)
+    args = ap.parse_args()
+
+    papdata = _load_json(args.papdata)
+    patterns = _load_json(args.patterns)
+    M, ts_minutes, pids, loc_ids, n_homes = build_arrays_from_legacy(patterns, papdata)
+    blob = encode_patterns_binary(M, ts_minutes, pids, loc_ids, n_homes, level=args.level)
+    Path(args.out).write_bytes(blob)
+
+    print(
+        f"wrote {args.out}: {len(blob):,} bytes "
+        f"(matrix {M.shape[0]}x{M.shape[1]} {M.dtype}, "
+        f"{len(loc_ids):,} locations, n_homes={n_homes})",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/simulator/data_interface.py
+++ b/simulator/data_interface.py
@@ -1,12 +1,21 @@
-import requests 
+import requests
 import json
 import logging
 import sys
 import os
 from typing import Dict, Any, Generator, Optional
 from simulator.config import DELINEO
+from simulator.patterns_codec import is_binary_patterns, decode_patterns_binary
 
 BASE_URL = DELINEO['DB_URL']
+
+
+def _decode_patterns_body(body: bytes):
+    """Decode the patterns half of a bulk response: binary if it carries the
+    DLNOPAT magic, else the legacy UTF-8 JSON object."""
+    if is_binary_patterns(body):
+        return decode_patterns_binary(body)
+    return json.loads(body.decode('utf-8'))
 
 def stream_data(url = f"{BASE_URL}patterns/1?stream=true"):
     with requests.get(url, stream=True) as response:
@@ -85,30 +94,35 @@ class StreamDataLoader:
     @staticmethod
     def load_bulk(url: str, timeout: int = 360) -> tuple:
         """
-        Fetch bulk data: first line is papdata JSON, remainder is raw patterns JSON.
-        Returns (papdata_dict, patterns_dict).
+        Fetch bulk data: first line is papdata JSON, remainder is the patterns
+        body (legacy JSON, or the DLNOPAT binary format — auto-detected).
+        Returns (papdata_dict, patterns) where patterns is a dict (JSON) or a
+        BinaryPatterns (binary).
         """
         logging.info(f"Fetching bulk data from: {url}")
         headers = {
-            'Accept': 'application/json, text/plain, */*',
+            'Accept': 'application/json, text/plain, */*, application/octet-stream',
             'Cache-Control': 'no-cache',
         }
         with requests.get(url, stream=True, headers=headers, timeout=timeout) as response:
             response.raise_for_status()
             it = response.iter_content(chunk_size=1024 * 1024)
             buf = b''
+            newline_pos = -1
             # Read chunks until we find the first newline (end of papdata)
             for chunk in it:
                 buf += chunk
                 newline_pos = buf.find(b'\n')
                 if newline_pos != -1:
                     break
+            if newline_pos == -1:
+                raise ValueError("bulk response missing papdata newline delimiter")
             papdata = json.loads(buf[:newline_pos].decode('utf-8'))
-            # Collect the rest as patterns JSON
+            # Collect the rest as the patterns body, then sniff its format.
             chunks = [buf[newline_pos + 1:]]
             for chunk in it:
                 chunks.append(chunk)
-            patterns = json.loads(b''.join(chunks).decode('utf-8'))
+            patterns = _decode_patterns_body(b''.join(chunks))
             return papdata, patterns
 
     @staticmethod

--- a/simulator/infectionmgr.py
+++ b/simulator/infectionmgr.py
@@ -173,6 +173,11 @@ class InfectionManager:
         # _next_transition_time was based on the old (empty or stale) timeline.
         target_person._next_transition_time = 0
         self.infected.add(person.id)
+        # Keep the SoA ever-infected mask in sync (engine mode); schedule_infection
+        # is the single chokepoint for every infection (seed + kernel).
+        store = getattr(simulator, "membership", None)
+        if store is not None:
+            store.mark_infected(person.id)
 
         if people_with_timelines is not None:
             # Store the Person ref directly (not pid string) so update_people_states

--- a/simulator/membership.py
+++ b/simulator/membership.py
@@ -61,6 +61,12 @@ class MembershipStore:
         # transmission kernel map an occupancy person-index back to its Person
         # via an O(1) list index instead of a dict lookup.
         self.idx_to_person: list = [None] * n
+        # Monotonic ever-infected mask (set via mark_infected at every
+        # schedule_infection); powers the numeric per-location infected count.
+        self.infected_mask: np.ndarray = np.zeros(n, dtype=bool)
+        # Households occupy the first n_homes location indices (see how
+        # location_keys is built: households then facilities).
+        self.n_homes: int = sum(1 for _, is_hh in self.idx_to_loc if is_hh)
         # pid-string array for fast snapshot gather (idx_to_pid as object array).
         self._pid_arr: np.ndarray = np.array(self.idx_to_pid, dtype=object)
         # Per-timestep movement, precomputed from patterns (see precompute_movement):
@@ -103,6 +109,35 @@ class MembershipStore:
                 np.asarray(persons, dtype=np.int32),
                 np.asarray(locs, dtype=np.int32),
             )
+
+    def mark_infected(self, pid: str) -> None:
+        idx = self.pid_to_idx.get(str(pid))
+        if idx is not None:
+            self.infected_mask[idx] = True
+
+    def movement_snapshot_numeric(self) -> dict:
+        """Per-location [count, infected] in homes/places order, via two
+        bincounts — O(N) numpy, ~50x cheaper than materializing pid lists.
+
+        Output: {"h": [c0,i0, c1,i1, ...], "p": [...]} matching the map-cache
+        shape the Next sim-processor builds, so the frontend consumes it directly.
+        """
+        pl = self.person_loc
+        placed = pl >= 0
+        locs = pl[placed]
+        L = self.num_locations
+        counts = np.bincount(locs, minlength=L)
+        inf = np.bincount(
+            locs, weights=self.infected_mask[placed], minlength=L
+        ).astype(np.int64)
+        H = self.n_homes
+        h = np.empty(2 * H, dtype=np.int64)
+        h[0::2] = counts[:H]
+        h[1::2] = inf[:H]
+        p = np.empty(2 * (L - H), dtype=np.int64)
+        p[0::2] = counts[H:]
+        p[1::2] = inf[H:]
+        return {"h": h.tolist(), "p": p.tolist()}
 
     def apply_movement(self, ts: int) -> bool:
         """Vectorized scatter: place everyone listed at timestep ts. No-op-safe."""

--- a/simulator/membership.py
+++ b/simulator/membership.py
@@ -150,6 +150,23 @@ class MembershipStore:
         p[1::2] = inf[H:]
         return {"h": h.tolist(), "p": p.tolist()}
 
+    def movement_meta(self) -> dict:
+        """One-time decode tables for the per-person ``loc`` stream.
+
+        The numeric snapshot's per-timestep ``loc`` is ``person_loc`` (person
+        index -> location index). These tables let a consumer turn that back into
+        per-location pid lists without the engine ever materializing them:
+          - ``pids[person_idx]``  -> person id
+          - ``loc_ids[loc_idx]``  -> location id (homes first, then places)
+          - ``n_homes``           -> split point; ``loc_idx < n_homes`` is a home
+        Written once per run (non-numeric key, so timestep consumers skip it).
+        """
+        return {
+            "pids": list(self.idx_to_pid),
+            "loc_ids": [loc_id for loc_id, _ in self.idx_to_loc],
+            "n_homes": int(self.n_homes),
+        }
+
     def apply_movement(self, ts: int) -> bool:
         """Vectorized scatter: place everyone listed at timestep ts. No-op-safe."""
         entry = self._move.get(ts)

--- a/simulator/membership.py
+++ b/simulator/membership.py
@@ -1,0 +1,84 @@
+"""Struct-of-arrays location membership (Step 1 scaffolding).
+
+`MembershipStore` holds the canonical *location membership* of every person in
+parallel NumPy arrays instead of the per-`Location` `population` dict:
+
+    person_loc:  int32[N]  -- current location index per person (-1 = unplaced)
+    arrival_seq: int64[N]  -- monotonic counter stamped on each placement
+
+`occupancy_view()` groups people by location with a single counting sort,
+producing contiguous per-location slices (`occupants[start:start+count]`). The
+secondary sort key is `arrival_seq`, so within a location the order reproduces
+the dict's insertion order (= arrival order, since `move_people` does
+remove-then-append). That stable ordering is what keeps the movement snapshot
+byte-identical when consumers switch from the dict to this view.
+
+This module is wiring only: in Step 1 it runs in *shadow* mode alongside the
+dicts (behind `DELINEO_SOA_SHADOW`) so we can assert the two agree before any
+consumer reads from it.
+"""
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import numpy as np
+
+
+class OccupancyView(NamedTuple):
+    """People grouped by location for one timestep.
+
+    For location index ``l``, its occupant person-indices (in arrival order) are
+    ``occupants[starts[l] : starts[l] + counts[l]]``.
+    """
+
+    counts: np.ndarray   # int32[L]
+    starts: np.ndarray   # int32[L]   (exclusive prefix sum of counts)
+    occupants: np.ndarray  # int32[num_placed]  person indices, grouped by loc
+
+    def occupants_of(self, loc_idx: int) -> np.ndarray:
+        start = self.starts[loc_idx]
+        return self.occupants[start : start + self.counts[loc_idx]]
+
+
+class MembershipStore:
+    def __init__(self, person_ids: list[str], location_keys: list[tuple[str, bool]]) -> None:
+        # Person index space.
+        self.idx_to_pid: list[str] = [str(p) for p in person_ids]
+        self.pid_to_idx: dict[str, int] = {pid: i for i, pid in enumerate(self.idx_to_pid)}
+        # Location index space (households + facilities share one space; the key
+        # is (id, is_household) because a household and a facility can share an id).
+        self.idx_to_loc: list[tuple[str, bool]] = list(location_keys)
+        self.loc_to_idx: dict[tuple[str, bool], int] = {
+            key: i for i, key in enumerate(self.idx_to_loc)
+        }
+
+        n = len(self.idx_to_pid)
+        self.person_loc: np.ndarray = np.full(n, -1, dtype=np.int32)
+        self.arrival_seq: np.ndarray = np.zeros(n, dtype=np.int64)
+        self._seq: int = 0
+
+    @property
+    def num_locations(self) -> int:
+        return len(self.idx_to_loc)
+
+    def note_placement(self, pid: str, loc_idx: int) -> None:
+        """Record that person ``pid`` is now at location index ``loc_idx``."""
+        pidx = self.pid_to_idx[str(pid)]
+        self.person_loc[pidx] = loc_idx
+        self.arrival_seq[pidx] = self._seq
+        self._seq += 1
+
+    def occupancy_view(self) -> OccupancyView:
+        placed_mask = self.person_loc >= 0
+        placed_idx = np.nonzero(placed_mask)[0].astype(np.int32)
+        locs = self.person_loc[placed_idx]
+        seqs = self.arrival_seq[placed_idx]
+        # Primary key location, secondary key arrival_seq -> within-location order
+        # matches dict insertion order.
+        order = np.lexsort((seqs, locs))
+        occupants = placed_idx[order]
+        counts = np.bincount(locs, minlength=self.num_locations).astype(np.int32)
+        starts = np.zeros(self.num_locations, dtype=np.int32)
+        if self.num_locations > 1:
+            np.cumsum(counts[:-1], out=starts[1:])
+        return OccupancyView(counts=counts, starts=starts, occupants=occupants)

--- a/simulator/membership.py
+++ b/simulator/membership.py
@@ -57,9 +57,83 @@ class MembershipStore:
         self.arrival_seq: np.ndarray = np.zeros(n, dtype=np.int64)
         self._seq: int = 0
 
+        # Filled by set_person_refs once Person objects exist; lets the
+        # transmission kernel map an occupancy person-index back to its Person
+        # via an O(1) list index instead of a dict lookup.
+        self.idx_to_person: list = [None] * n
+        # pid-string array for fast snapshot gather (idx_to_pid as object array).
+        self._pid_arr: np.ndarray = np.array(self.idx_to_pid, dtype=object)
+        # Per-timestep movement, precomputed from patterns (see precompute_movement):
+        #   _move[ts] = (person_idx int32[], loc_idx int32[])
+        self._move: dict[int, tuple] = {}
+
     @property
     def num_locations(self) -> int:
         return len(self.idx_to_loc)
+
+    def set_person_refs(self, get_person) -> None:
+        """Populate idx_to_person from a pid -> Person resolver."""
+        for i, pid in enumerate(self.idx_to_pid):
+            self.idx_to_person[i] = get_person(pid)
+
+    def precompute_movement(self, patterns: dict, max_length: int) -> None:
+        """Convert patterns into per-timestep (person_idx, loc_idx) arrays.
+
+        Each timestep's patterns list every person at their location, so applying
+        these arrays fully sets person_loc (a vectorized scatter) — replacing the
+        per-person dict remove/add loop in move_people. Done once at build.
+        """
+        pid_to_idx = self.pid_to_idx
+        loc_to_idx = self.loc_to_idx
+        for ts_str, data in patterns.items():
+            ts = int(ts_str)
+            if ts > max_length or not isinstance(data, dict):
+                continue
+            persons: list[int] = []
+            locs: list[int] = []
+            for poi_type, is_hh in (("homes", True), ("places", False)):
+                for loc_id, pids in data.get(poi_type, {}).items():
+                    loc_idx = loc_to_idx[(str(loc_id), is_hh)]
+                    for pid in pids:
+                        pidx = pid_to_idx.get(str(pid))
+                        if pidx is not None:
+                            persons.append(pidx)
+                            locs.append(loc_idx)
+            self._move[ts] = (
+                np.asarray(persons, dtype=np.int32),
+                np.asarray(locs, dtype=np.int32),
+            )
+
+    def apply_movement(self, ts: int) -> bool:
+        """Vectorized scatter: place everyone listed at timestep ts. No-op-safe."""
+        entry = self._move.get(ts)
+        if entry is None:
+            return False
+        person_idx, loc_idx = entry
+        self.person_loc[person_idx] = loc_idx
+        return True
+
+    def movement_snapshot(self) -> dict:
+        """Build the pid-string movement snapshot from person_loc (numpy gather).
+
+        UI-compatible (same {homes,places: {loc_id: [pids]}} shape). The numeric
+        form (movement_snapshot_numeric) is ~50x cheaper but needs the consumer
+        to change; this keeps the engine win (vectorized movement) independent of
+        the frontend.
+        """
+        view = self.occupancy_view()
+        pid_arr = self._pid_arr
+        counts, starts, occupants = view.counts, view.starts, view.occupants
+        homes: dict = {}
+        places: dict = {}
+        for loc_idx, (loc_id, is_hh) in enumerate(self.idx_to_loc):
+            count = counts[loc_idx]
+            if count == 0:
+                continue
+            start = starts[loc_idx]
+            pids = pid_arr[occupants[start : start + count]].tolist()
+            (homes if is_hh else places)[loc_id] = pids
+        return {"homes": homes, "places": places}
 
     def note_placement(self, pid: str, loc_idx: int) -> None:
         """Record that person ``pid`` is now at location index ``loc_idx``."""

--- a/simulator/membership.py
+++ b/simulator/membership.py
@@ -64,6 +64,14 @@ class MembershipStore:
         # Monotonic ever-infected mask (set via mark_infected at every
         # schedule_infection); powers the numeric per-location infected count.
         self.infected_mask: np.ndarray = np.zeros(n, dtype=bool)
+        # Hot per-person scalars mirrored for the (future) vectorized kernel.
+        # pstate holds the single-variant InfectionState value (0 = SUSCEPTIBLE);
+        # maintained in update_people_states. masked / vax factors default to the
+        # no-intervention case and are updated when interventions apply.
+        self.pstate: np.ndarray = np.zeros(n, dtype=np.int8)
+        self.masked: np.ndarray = np.zeros(n, dtype=bool)
+        self.vax_trans_factor: np.ndarray = np.ones(n, dtype=np.float32)
+        self.vax_inf_protection: np.ndarray = np.zeros(n, dtype=np.float32)
         # Households occupy the first n_homes location indices (see how
         # location_keys is built: households then facilities).
         self.n_homes: int = sum(1 for _, is_hh in self.idx_to_loc if is_hh)
@@ -78,9 +86,12 @@ class MembershipStore:
         return len(self.idx_to_loc)
 
     def set_person_refs(self, get_person) -> None:
-        """Populate idx_to_person from a pid -> Person resolver."""
+        """Populate idx_to_person and stamp each Person with its store index."""
         for i, pid in enumerate(self.idx_to_pid):
-            self.idx_to_person[i] = get_person(pid)
+            person = get_person(pid)
+            self.idx_to_person[i] = person
+            if person is not None:
+                person._soa_idx = i
 
     def precompute_movement(self, patterns: dict, max_length: int) -> None:
         """Convert patterns into per-timestep (person_idx, loc_idx) arrays.

--- a/simulator/membership.py
+++ b/simulator/membership.py
@@ -23,6 +23,8 @@ from typing import NamedTuple
 
 import numpy as np
 
+from simulator.patterns_codec import BinaryPatterns
+
 
 class OccupancyView(NamedTuple):
     """People grouped by location for one timestep.
@@ -99,7 +101,14 @@ class MembershipStore:
         Each timestep's patterns list every person at their location, so applying
         these arrays fully sets person_loc (a vectorized scatter) — replacing the
         per-person dict remove/add loop in move_people. Done once at build.
+
+        Accepts either the legacy ``{ts: {homes, places}}`` dict (the per-person
+        Python loop below) or a decoded ``BinaryPatterns`` (a vectorized fast path
+        that skips both json.loads and this loop — see patterns_codec).
         """
+        if isinstance(patterns, BinaryPatterns):
+            self._precompute_movement_binary(patterns, max_length)
+            return
         pid_to_idx = self.pid_to_idx
         loc_to_idx = self.loc_to_idx
         for ts_str, data in patterns.items():
@@ -120,6 +129,47 @@ class MembershipStore:
                 np.asarray(persons, dtype=np.int32),
                 np.asarray(locs, dtype=np.int32),
             )
+
+    def _precompute_movement_binary(self, bp: BinaryPatterns, max_length: int) -> None:
+        """Vectorized precompute from a dense location matrix.
+
+        The producer's column/location enumeration may differ from ours, so we
+        remap its id tables through our own pid_to_idx / loc_to_idx (once), then
+        each timestep is a single numpy gather. Columns whose pid isn't in our
+        population are dropped — matching the legacy loop's ``pid_to_idx.get``.
+        """
+        # Producer location index -> our location index, by (id, is_home) key.
+        # Tolerant (-1 = absent from this run's locations); we only fail if such a
+        # location is actually referenced within max_length — mirroring the legacy
+        # loop, which never looks up unreferenced / beyond-window locations.
+        loc_remap = np.fromiter(
+            (
+                self.loc_to_idx.get((bp.loc_ids[j], j < bp.n_homes), -1)
+                for j in range(len(bp.loc_ids))
+            ),
+            dtype=np.int64,
+            count=len(bp.loc_ids),
+        )
+        # Producer column -> our person index (-1 = not in our population; dropped,
+        # matching the legacy loop's pid_to_idx.get).
+        person_remap = np.fromiter(
+            (self.pid_to_idx.get(pid, -1) for pid in bp.pids),
+            dtype=np.int64,
+            count=len(bp.pids),
+        )
+        valid = person_remap >= 0
+        person_idx = person_remap[valid].astype(np.int32)
+        for row, minute in enumerate(bp.ts_minutes):
+            if minute > max_length:
+                continue
+            loc_idx = loc_remap[bp.loc_matrix[row]][valid]
+            if (loc_idx < 0).any():
+                bad = np.unique(bp.loc_matrix[row][valid][loc_idx < 0])[:5]
+                raise ValueError(
+                    f"patterns timestep {minute} references locations "
+                    f"{[bp.loc_ids[b] for b in bad]} absent from this run's papdata"
+                )
+            self._move[minute] = (person_idx, loc_idx.astype(np.int32))
 
     def mark_infected(self, pid: str) -> None:
         idx = self.pid_to_idx.get(str(pid))

--- a/simulator/membership.py
+++ b/simulator/membership.py
@@ -71,6 +71,14 @@ class MembershipStore:
         # maintained in update_people_states. masked / vax factors default to the
         # no-intervention case and are updated when interventions apply.
         self.pstate: np.ndarray = np.zeros(n, dtype=np.int8)
+        # Per-person SNAPSHOT state, mirroring variant_infected (the per-step
+        # infection map): 0 where never-infected, else the last recorded state
+        # value. Differs from pstate for just-infected (variant_infected is
+        # written by the transmission kernel a step before pstate updates) and
+        # for waned-to-susceptible (variant_infected keeps the last non-zero
+        # value). Powers the per-place dot counts so the frontend doesn't
+        # reconstruct them per person. Maintained wherever variant_infected is.
+        self.snap_state: np.ndarray = np.zeros(n, dtype=np.int8)
         self.masked: np.ndarray = np.zeros(n, dtype=bool)
         self.vax_trans_factor: np.ndarray = np.ones(n, dtype=np.float32)
         self.vax_inf_protection: np.ndarray = np.zeros(n, dtype=np.float32)
@@ -199,6 +207,35 @@ class MembershipStore:
         p[0::2] = counts[H:]
         p[1::2] = inf[H:]
         return {"h": h.tolist(), "p": p.tolist()}
+
+    # State-bit groups for the dot view (mirror the frontend's masks):
+    # recovered takes precedence over an active infection.
+    _DOT_RECOVERED = 16  # InfectionState.RECOVERED
+    _DOT_ACTIVE = 1 | 2 | 4 | 8  # INFECTED|INFECTIOUS|SYMPTOMATIC|HOSPITALIZED
+
+    def place_dot_counts(self) -> list:
+        """Per-place ``[infected, recovered]`` (places only, in places order),
+        from ``snap_state`` so it equals the frontend's per-person dot bake.
+
+        Recovered takes precedence over active infection (matching the dots
+        view). ``O(N)`` numpy (two bincounts) — lets the frontend read per-place
+        dot counts directly instead of reconstructing them from the per-person
+        ``loc`` stream.
+        """
+        pl = self.person_loc
+        placed = pl >= 0
+        loc = pl[placed]
+        s = self.snap_state[placed]
+        rec = (s & self._DOT_RECOVERED) != 0
+        inf = (~rec) & ((s & self._DOT_ACTIVE) != 0)
+        L = self.num_locations
+        rec_counts = np.bincount(loc, weights=rec, minlength=L)
+        inf_counts = np.bincount(loc, weights=inf, minlength=L)
+        H = self.n_homes
+        out = np.empty(2 * (L - H), dtype=np.int64)
+        out[0::2] = inf_counts[H:].astype(np.int64)
+        out[1::2] = rec_counts[H:].astype(np.int64)
+        return out.tolist()
 
     def movement_meta(self) -> dict:
         """One-time decode tables for the per-person ``loc`` stream.

--- a/simulator/membership.py
+++ b/simulator/membership.py
@@ -113,15 +113,16 @@ class MembershipStore:
         self.person_loc[person_idx] = loc_idx
         return True
 
-    def movement_snapshot(self) -> dict:
+    def movement_snapshot(self, view: "OccupancyView | None" = None) -> dict:
         """Build the pid-string movement snapshot from person_loc (numpy gather).
 
         UI-compatible (same {homes,places: {loc_id: [pids]}} shape). The numeric
-        form (movement_snapshot_numeric) is ~50x cheaper but needs the consumer
-        to change; this keeps the engine win (vectorized movement) independent of
-        the frontend.
+        form is ~50x cheaper but needs the consumer to change; this keeps the
+        engine win (vectorized movement) independent of the frontend. Pass a
+        prebuilt OccupancyView to avoid recomputing it.
         """
-        view = self.occupancy_view()
+        if view is None:
+            view = self.occupancy_view()
         pid_arr = self._pid_arr
         counts, starts, occupants = view.counts, view.starts, view.occupants
         homes: dict = {}

--- a/simulator/pap.py
+++ b/simulator/pap.py
@@ -60,6 +60,11 @@ class Location:
         self.location_type: str = location_type
         self.area: Optional[float] = area    # physical floor area in m^2 (None = unknown)
         self.population: dict[str, Person] = {}
+        # SoA shadow (Step 1): when a MembershipStore is attached, add_member
+        # also records the placement into person_loc. Left None in production so
+        # the hot path is a single `is not None` check. See membership.py.
+        self._membership = None              # Optional[MembershipStore]
+        self._loc_idx: int = -1              # this location's index in the store
 
     # population management
 
@@ -69,6 +74,8 @@ class Location:
 
     def add_member(self, person: Person) -> None:
         self.population[str(person.id)] = person
+        if self._membership is not None:
+            self._membership.note_placement(person.id, self._loc_idx)
 
     def remove_member(self, person_id: str) -> None:
         self.population.pop(str(person_id), None)

--- a/simulator/pap.py
+++ b/simulator/pap.py
@@ -129,6 +129,7 @@ class Person:
 
     def __init__(self, id: str, sex: int, age: int, household: Household) -> None:
         self.id: str = id
+        self._soa_idx: int = -1     # index into MembershipStore arrays (engine mode)
         self.sex: int = sex         # 0 = male, 1 = female
         self.age: int = age
         self.household: Household = household

--- a/simulator/patterns_codec.py
+++ b/simulator/patterns_codec.py
@@ -1,0 +1,276 @@
+"""Binary "patterns" movement format (DLNOPAT1).
+
+The movement schedule ("patterns") is, by construction, a *full population
+snapshot* per timestep: every person is at exactly one location at every
+timestep (verified empirically — see COLUMNAR_PATTERNS_DESIGN.md). So it encodes
+losslessly as a dense matrix ``M[timestep, person] = location_index`` with the
+person id implicit in the column. That replaces the ~424 MB JSON blob (~65 s to
+parse + ~14 s per-person index loop) with a ~28 MB zstd buffer that decodes via
+``np.frombuffer`` + a vectorized id-remap in well under a second.
+
+On-wire layout (all integers little-endian):
+
+    magic        char[8]   b"DLNOPAT1"  (trailing digit = format version)
+    layout       u8        0 = full-snapshot dense (1 = delta/CSR, reserved)
+    dtype        u8        0 = uint16, 1 = uint32   (matrix value dtype)
+    orientation  u8        0 = ts-major [T, N]      (1 = person-major, reserved)
+    codec        u8        0 = none, 1 = zstd, 2 = gzip
+    T            u32       number of timesteps
+    N            u32       number of persons (matrix columns)
+    L            u32       number of locations (len(loc_ids))
+    n_homes      u32       split point: location index < n_homes is a home
+    ts_minutes   u32[T]    the timestep keys in minutes (60, 120, ...)
+    pids_len     u32 ; pids_blob    (utf-8, newline-joined person ids; column -> pid)
+    locids_len   u32 ; locids_blob  (utf-8, newline-joined location ids; index -> id)
+    raw_nbytes   u64       decompressed payload size (= T*N*itemsize), for integrity
+    comp_nbytes  u64 ; payload         (the codec frame of the C-order matrix bytes)
+
+The producer (Algorithms) and consumer (Simulation) agree only on this layout,
+NOT on a shared integer id space: the producer's own string id tables ride in
+the header and the consumer re-maps them through its papdata-built index spaces,
+so producer/consumer enumeration order can differ without corruption.
+"""
+from __future__ import annotations
+
+import struct
+
+import numpy as np
+
+MAGIC = b"DLNOPAT1"
+
+LAYOUT_DENSE = 0
+
+_DTYPE_TO_CODE = {2: 0, 4: 1}          # itemsize -> dtype code
+_CODE_TO_DTYPE = {0: np.uint16, 1: np.uint32}
+
+ORIENT_TS_MAJOR = 0
+
+CODEC_NONE, CODEC_ZSTD, CODEC_GZIP = 0, 1, 2
+
+# Header up to (but not including) the variable-length blocks.
+_FIXED = struct.Struct("<8sBBBBIIII")
+
+
+def is_binary_patterns(head: bytes) -> bool:
+    """True if a body begins with the binary-patterns magic."""
+    return head[: len(MAGIC)] == MAGIC
+
+
+def _split_id_table(blob: bytes) -> list:
+    """Decode a newline-joined id table. Empty blob -> [] (not [''])."""
+    return blob.decode("utf-8").split("\n") if blob else []
+
+
+def _compress(raw: bytes, level: int) -> tuple[int, bytes]:
+    """Compress with zstd; fall back to stdlib gzip if zstandard is absent.
+
+    The codec byte makes the choice self-describing, so a buffer produced where
+    zstandard is unavailable still decodes everywhere.
+    """
+    try:
+        import zstandard
+
+        return CODEC_ZSTD, zstandard.ZstdCompressor(level=level).compress(raw)
+    except ImportError:
+        import gzip
+
+        return CODEC_GZIP, gzip.compress(raw, compresslevel=6)
+
+
+def _decompress(codec: int, blob: bytes, raw_nbytes: int) -> bytes:
+    if codec == CODEC_NONE:
+        return blob
+    if codec == CODEC_ZSTD:
+        try:
+            import zstandard
+        except ImportError as e:
+            raise RuntimeError(
+                "patterns buffer is zstd-compressed but the 'zstandard' package "
+                "is not installed"
+            ) from e
+
+        return zstandard.ZstdDecompressor().decompress(blob, max_output_size=raw_nbytes)
+    if codec == CODEC_GZIP:
+        import gzip
+
+        return gzip.decompress(blob)
+    raise ValueError(f"unknown patterns codec byte: {codec}")
+
+
+class BinaryPatterns:
+    """Decoded binary patterns: a dense location-index matrix + decode tables.
+
+    Carries the producer's own id tables (``pids``, ``loc_ids``, ``n_homes``) so
+    a consumer can re-map them onto its own index spaces. Supports the dict-like
+    ``items()`` the legacy (non-engine) consumers expect, reconstructing each
+    timestep's ``{homes, places}`` lazily; the engine path skips that entirely
+    via the dense matrix.
+    """
+
+    def __init__(
+        self,
+        loc_matrix: np.ndarray,
+        ts_minutes: list[int],
+        pids: list[str],
+        loc_ids: list[str],
+        n_homes: int,
+    ) -> None:
+        self.loc_matrix = loc_matrix          # [T, N], value = producer location index
+        self.ts_minutes = ts_minutes          # length T
+        self.pids = pids                      # length N: column -> person id (str)
+        self.loc_ids = loc_ids                # length L: location index -> id (str)
+        self.n_homes = int(n_homes)
+
+    def _timestep_dict(self, row: int) -> dict:
+        """Reconstruct the legacy ``{homes, places}`` shape for one timestep."""
+        locs = self.loc_matrix[row]
+        pids = self.pids
+        loc_ids = self.loc_ids
+        n_homes = self.n_homes
+        homes: dict = {}
+        places: dict = {}
+        for col in range(locs.shape[0]):
+            lidx = int(locs[col])
+            bucket = homes if lidx < n_homes else places
+            bucket.setdefault(loc_ids[lidx], []).append(pids[col])
+        return {"homes": homes, "places": places}
+
+    def items(self):
+        """Yield ``(ts_str, {homes, places})`` per timestep (legacy consumers).
+
+        Within-location member order is the person-column order (the producer's
+        person enumeration). The format does not preserve the producer's original
+        per-location list order — there is no such order in a person-keyed matrix.
+        The engine path is order-independent (a person->loc scatter), so this is
+        byte-equivalent there; the non-engine path's RNG *is* order-sensitive, so
+        it is byte-equivalent only when the producer's lists already match this
+        canonical order (the current producer sorts by person id), and otherwise
+        statistically (ensemble) equivalent. See COLUMNAR_PATTERNS_DESIGN.md.
+        """
+        for row, minute in enumerate(self.ts_minutes):
+            yield str(minute), self._timestep_dict(row)
+
+
+def encode_patterns_binary(
+    loc_matrix: np.ndarray,
+    ts_minutes,
+    pids,
+    loc_ids,
+    n_homes: int,
+    level: int = 3,
+) -> bytes:
+    """Serialize a dense [T, N] location-index matrix to the binary format."""
+    L = len(loc_ids)
+    dtype = np.uint16 if L <= 65536 else np.uint32
+    if int(loc_matrix.max(initial=0)) >= L:
+        raise ValueError("location index in matrix exceeds len(loc_ids)")
+    # Force C-order little-endian so the bytes are portable across hosts.
+    m = np.ascontiguousarray(loc_matrix, dtype=np.dtype(dtype).newbyteorder("<"))
+    T, N = m.shape
+    if N != len(pids):
+        raise ValueError(f"matrix has {N} columns but {len(pids)} pids")
+
+    raw = m.tobytes()
+    codec, payload = _compress(raw, level)
+
+    pids_blob = "\n".join(pids).encode("utf-8")
+    locids_blob = "\n".join(loc_ids).encode("utf-8")
+    ts_arr = np.asarray(ts_minutes, dtype="<u4")
+    if ts_arr.shape[0] != T:
+        raise ValueError(f"{T} matrix rows but {ts_arr.shape[0]} ts_minutes")
+
+    out = bytearray()
+    out += _FIXED.pack(
+        MAGIC, LAYOUT_DENSE, _DTYPE_TO_CODE[np.dtype(dtype).itemsize],
+        ORIENT_TS_MAJOR, codec, T, N, L, int(n_homes),
+    )
+    out += ts_arr.tobytes()
+    out += struct.pack("<I", len(pids_blob)) + pids_blob
+    out += struct.pack("<I", len(locids_blob)) + locids_blob
+    out += struct.pack("<QQ", len(raw), len(payload)) + payload
+    return bytes(out)
+
+
+def decode_patterns_binary(data: bytes) -> BinaryPatterns:
+    """Parse the binary format back into a :class:`BinaryPatterns`."""
+    if not is_binary_patterns(data):
+        raise ValueError("not a DLNOPAT binary patterns buffer")
+    magic, layout, dtype_code, orient, codec, T, N, L, n_homes = _FIXED.unpack_from(data, 0)
+    if layout != LAYOUT_DENSE or orient != ORIENT_TS_MAJOR:
+        raise ValueError(f"unsupported layout/orientation: {layout}/{orient}")
+    off = _FIXED.size
+
+    ts_arr = np.frombuffer(data, dtype="<u4", count=T, offset=off)
+    off += 4 * T
+    ts_minutes = ts_arr.astype(np.int64).tolist()
+
+    (pids_len,) = struct.unpack_from("<I", data, off); off += 4
+    pids = _split_id_table(data[off : off + pids_len]); off += pids_len
+    (locids_len,) = struct.unpack_from("<I", data, off); off += 4
+    loc_ids = _split_id_table(data[off : off + locids_len]); off += locids_len
+    if len(pids) != N:
+        raise ValueError(f"decoded {len(pids)} pids but matrix has {N} columns")
+    if len(loc_ids) != L:
+        raise ValueError(f"decoded {len(loc_ids)} loc_ids but header declares L={L}")
+
+    raw_nbytes, comp_nbytes = struct.unpack_from("<QQ", data, off); off += 16
+    payload = data[off : off + comp_nbytes]
+    raw = _decompress(codec, payload, raw_nbytes)
+    if len(raw) != raw_nbytes:
+        raise ValueError(f"patterns payload truncated: {len(raw)} != {raw_nbytes}")
+
+    dtype = np.dtype(_CODE_TO_DTYPE[dtype_code]).newbyteorder("<")
+    matrix = np.frombuffer(raw, dtype=dtype, count=T * N).reshape(T, N)
+    return BinaryPatterns(matrix, ts_minutes, pids, loc_ids, n_homes)
+
+
+def build_arrays_from_legacy(patterns: dict, papdata: dict):
+    """Transcode the legacy ``{ts: {homes, places: {id: [pids]}}}`` shape into the
+    dense arrays the binary format stores.
+
+    Person columns and location indices are enumerated from papdata (sorted by
+    integer id), homes first then places. Used by the offline transcoder and the
+    Algorithms producer reference; the consumer never calls this.
+    """
+    pids = sorted((str(p) for p in papdata["people"]), key=int)
+    homes = sorted((str(h) for h in papdata["homes"]), key=int)
+    places = sorted((str(p) for p in papdata["places"]), key=int)
+    loc_ids = homes + places
+    n_homes = len(homes)
+
+    pid_col = {pid: i for i, pid in enumerate(pids)}
+    loc_idx = {(hid, True): i for i, hid in enumerate(homes)}
+    loc_idx.update({(pid, False): n_homes + i for i, pid in enumerate(places)})
+
+    ts_minutes = sorted(int(ts) for ts in patterns)
+    T, N = len(ts_minutes), len(pids)
+    # The sentinel (= len(loc_ids)) must also fit the dtype, so uint16 only holds
+    # up to 65535 locations (real indices 0..65534 + sentinel 65535).
+    dtype = np.uint16 if len(loc_ids) < 65536 else np.uint32
+    # Sentinel L marks "unset"; a true full snapshot leaves none behind.
+    sentinel = len(loc_ids)
+    M = np.full((T, N), sentinel, dtype=dtype)
+
+    for row, minute in enumerate(ts_minutes):
+        data = patterns[str(minute)]
+        for poi_type, is_hh in (("homes", True), ("places", False)):
+            for loc_id, members in data.get(poi_type, {}).items():
+                key = (str(loc_id), is_hh)
+                if key not in loc_idx:
+                    kind = "home" if is_hh else "place"
+                    raise ValueError(
+                        f"patterns reference {kind} id {loc_id!r} at minute "
+                        f"{minute} not present in papdata"
+                    )
+                li = loc_idx[key]
+                for pid in members:
+                    col = pid_col.get(str(pid))
+                    if col is not None:
+                        M[row, col] = li
+
+    unset = int((M == sentinel).sum())
+    if unset:
+        raise ValueError(
+            f"{unset} (timestep, person) cells unset — patterns is not a full snapshot"
+        )
+    return M, ts_minutes, pids, loc_ids, n_homes

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -40,15 +40,16 @@ def _perf_timings_enabled() -> bool:
     return os.getenv("DELINEO_PERF_TIMINGS", "").lower() in {"1", "true", "yes", "on"}
 
 
-def _engine_requested() -> bool:
-    """Whether the vectorized SoA engine is requested via env.
+def _engine_disabled() -> bool:
+    """Whether the vectorized SoA engine is explicitly turned OFF via env.
 
-    Parsed like every other boolean flag so ``DELINEO_SOA_ENGINE=0`` disables it
-    (the old ``bool(os.environ.get(...))`` was truthy-on-presence, so ``=0``
-    wrongly turned it ON). Requesting the engine does not force it: eligibility
-    (`SimulationRunner._engine_eligibility`) still decides whether it can run
-    this config safely, falling back to the non-engine path otherwise."""
-    return os.getenv("DELINEO_SOA_ENGINE", "").lower() in {"1", "true", "yes", "on"}
+    The engine is ON BY DEFAULT; ``DELINEO_SOA_ENGINE=0`` (or false/no/off) is
+    the kill switch that forces the legacy non-engine path for every run. Enabling
+    it is never a force: eligibility (`SimulationRunner._engine_eligibility`) still
+    decides whether the engine can run a given config correctly, falling back to
+    the non-engine path otherwise. (Any other value, including unset or ``1``,
+    leaves the default-on behavior in place.)"""
+    return os.getenv("DELINEO_SOA_ENGINE", "").lower() in {"0", "false", "no", "off"}
 
 
 def _log_perf_timing(label: str, started_at: float) -> None:
@@ -477,23 +478,25 @@ class SimulationRunner:
             intervention_weights=self.simdata["interventions"],
         )
         variants = self.simdata["variants"]
-        # The engine is REQUESTED via env, but only ENGAGED when it can run this
+        # The engine is ON BY DEFAULT, but only ENGAGED when it can run this
         # config correctly. Ineligible configs (movement interventions,
         # multi-variant, logging/agg constraints) transparently fall back to the
         # non-engine path instead of silently producing wrong results.
-        if _engine_requested():
+        # DELINEO_SOA_ENGINE=0 is the kill switch (forces non-engine everywhere).
+        if _engine_disabled():
+            self._soa_engine = False
+            logger.info("SoA engine disabled via DELINEO_SOA_ENGINE=0.")
+        else:
             eligible, reason = self._engine_eligibility(variants)
             self._soa_engine = eligible
             if not eligible:
                 logger.info(
-                    "SoA engine requested but not eligible (%s); falling back to "
-                    "the non-engine path for correct results.",
+                    "SoA engine not eligible (%s); falling back to the "
+                    "non-engine path for correct results.",
                     reason,
                 )
             else:
                 logger.info("SoA engine engaged (eligible config).")
-        else:
-            self._soa_engine = False
         # Single-variant engine mode derives infectious locations from occupancy,
         # so the event queue / _person_index (build_event_queue) is unnecessary.
         engine_no_queue = self._soa_engine and len(variants) == 1

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import gc
 import logging
 import math
 import os
@@ -316,18 +317,34 @@ class SimulationRunner:
         self._seed_random()
         total_start = time.perf_counter()
 
+        # The load+build phase allocates millions of long-lived objects (the
+        # patterns person-index, ~50k Person objects, the event queue). CPython's
+        # cyclic GC repeatedly rescans that growing set mid-build, which dominates
+        # setup — ~13x on the patterns parse (50s->4s) and ~2x on ingest_patterns
+        # (52s->24s). None of it is collectable during the build, so suspend GC
+        # for the whole setup and re-enable it for the run loop (which produces
+        # transient per-timestep garbage that should still be reclaimed).
+        # DELINEO_GC_TUNE=0 disables this (baseline behavior) for ablation.
+        gc_tune = os.environ.get("DELINEO_GC_TUNE", "1") != "0"
+        gc_was_enabled = gc.isenabled()
+        if gc_tune:
+            gc.disable()
         try:
-            stage_start = time.perf_counter()
-            loaded = self.load_data()
-            _log_perf_timing("load_data", stage_start)
-        except Exception as exc:
-            logger.exception("Failed to load data")
-            return {"error": str(exc)}
+            try:
+                stage_start = time.perf_counter()
+                loaded = self.load_data()
+                _log_perf_timing("load_data", stage_start)
 
-        try:
-            stage_start = time.perf_counter()
-            context = self.build_context(loaded)
-            _log_perf_timing("build_context", stage_start)
+                stage_start = time.perf_counter()
+                context = self.build_context(loaded)
+                _log_perf_timing("build_context", stage_start)
+            except Exception as exc:
+                logger.exception("Failed to load/build simulation context")
+                return {"error": str(exc)}
+            finally:
+                if gc_was_enabled:
+                    gc.enable()
+
             stage_start = time.perf_counter()
             self.run_queue(context)
             _log_perf_timing("run_queue", stage_start)
@@ -339,6 +356,9 @@ class SimulationRunner:
         except Exception as exc:
             logger.exception("Simulation runtime failed")
             return {"error": str(exc)}
+        finally:
+            if gc_was_enabled and not gc.isenabled():
+                gc.enable()
 
     def _progress(self, current_step, max_steps, message=None) -> None:
         if self.progress_callback:
@@ -412,6 +432,9 @@ class SimulationRunner:
                 self.simdata["initial_infected_count"],
             )
 
+        if os.environ.get("DELINEO_SOA_SHADOW"):
+            self._attach_membership_shadow(simulator, loaded.people_data)
+
         return SimulationContext(
             simulator=simulator,
             event_queue=event_queue,
@@ -424,6 +447,57 @@ class SimulationRunner:
             last_movement_ts=-simulator.timestep,
             initial_infected_ids=seeded_population.initial_infected_ids,
         )
+
+    def _attach_membership_shadow(self, simulator, people_data: dict) -> None:
+        """SoA Step 1 (shadow): build a MembershipStore alongside the dicts.
+
+        Attaches the store to every Location (so add_member mirrors placements
+        into person_loc) and backfills the current post-seed occupancy. Iterating
+        each location's population dict in order stamps arrival_seq so that, within
+        a location, the array order reproduces the dict's insertion order. Gated by
+        DELINEO_SOA_SHADOW — never runs in production.
+        """
+        from .membership import MembershipStore
+
+        location_keys = [(h.id, True) for h in simulator.households.values()]
+        location_keys += [(f.id, False) for f in simulator.facilities.values()]
+        store = MembershipStore(list(people_data.keys()), location_keys)
+
+        for loc_id, is_hh in location_keys:
+            loc = simulator.get_location(loc_id, is_hh)
+            loc._loc_idx = store.loc_to_idx[(loc_id, is_hh)]
+            loc._membership = store
+
+        for household in simulator.households.values():
+            for pid in household.population:
+                store.note_placement(pid, household._loc_idx)
+        for facility in simulator.facilities.values():
+            for pid in facility.population:
+                store.note_placement(pid, facility._loc_idx)
+
+        simulator.membership = store
+        self._shadow_mismatches = 0
+        self._shadow_checks = 0
+
+    def _shadow_validate_occupancy(self, simulator) -> None:
+        """Assert the OccupancyView reproduces the dict membership (order incl.)."""
+        store = getattr(simulator, "membership", None)
+        if store is None:
+            return
+        view = store.occupancy_view()
+        self._shadow_checks += 1
+        for loc_id, is_hh in store.idx_to_loc:
+            loc = simulator.get_location(loc_id, is_hh)
+            dict_order = list(loc.population.keys())
+            loc_idx = store.loc_to_idx[(loc_id, is_hh)]
+            arr_order = [store.idx_to_pid[i] for i in view.occupants_of(loc_idx)]
+            if dict_order != arr_order:
+                self._shadow_mismatches += 1
+                logger.warning(
+                    "SOA shadow mismatch at loc %s (hh=%s): dict=%d arr=%d first_diff=%s",
+                    loc_id, is_hh, len(dict_order), len(arr_order),
+                    next((i for i, (a, b) in enumerate(zip(dict_order, arr_order)) if a != b), "len"),
+                )
 
     def run_queue(self, context: SimulationContext) -> None:
         self._progress(0, context.max_length, "Running simulation...")
@@ -536,6 +610,9 @@ class SimulationRunner:
             for facility in context.simulator.facilities.values():
                 if facility.population:
                     context.simulator.logger.log_location_state(facility, ts_str)
+
+        if getattr(context.simulator, "membership", None) is not None:
+            self._shadow_validate_occupancy(context.simulator)
 
         with self._timed("write_snapshot/build_movement"):
             movement = build_movement_snapshot(context.simulator)

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -40,6 +40,17 @@ def _perf_timings_enabled() -> bool:
     return os.getenv("DELINEO_PERF_TIMINGS", "").lower() in {"1", "true", "yes", "on"}
 
 
+def _engine_requested() -> bool:
+    """Whether the vectorized SoA engine is requested via env.
+
+    Parsed like every other boolean flag so ``DELINEO_SOA_ENGINE=0`` disables it
+    (the old ``bool(os.environ.get(...))`` was truthy-on-presence, so ``=0``
+    wrongly turned it ON). Requesting the engine does not force it: eligibility
+    (`SimulationRunner._engine_eligibility`) still decides whether it can run
+    this config safely, falling back to the non-engine path otherwise."""
+    return os.getenv("DELINEO_SOA_ENGINE", "").lower() in {"1", "true", "yes", "on"}
+
+
 def _log_perf_timing(label: str, started_at: float) -> None:
     if _perf_timings_enabled():
         # Emit via print so the line is visible even when the simulator logger
@@ -419,6 +430,41 @@ class SimulationRunner:
             patterns_data=patterns_data,
         )
 
+    def _engine_eligibility(self, variants: list) -> tuple[bool, str]:
+        """Decide whether the vectorized engine can run this config *correctly*.
+
+        Engine mode replaces the per-Person ``move_people`` path with a fixed
+        precomputed location scatter, so it cannot apply movement-altering
+        interventions (capacity<1 / lockdown / selfiso reroute people home — see
+        ``move_people``) and is only vectorized for a single variant. Rather than
+        run those configs and silently drop the intervention (or read stale
+        Person/Location dicts for multi-variant), we report them ineligible and
+        fall back to the correct non-engine path. Returns ``(eligible, reason)``;
+        ``reason`` is empty when eligible.
+
+        Interventions are scanned across ALL scheduled time points, not just
+        t=0, since a movement intervention can be scheduled to start mid-run.
+        """
+        if not self.aggregate_transmission:
+            return False, "aggregate_transmission is off"
+        if self.enable_logging:
+            return False, "per-contact logging is on"
+        if len(variants) != 1:
+            return False, f"multi-variant run ({len(variants)} variants)"
+        non_trivial = [
+            iv
+            for iv in (self.simdata.get("interventions") or [])
+            if not _trivial_movement_interventions(iv)
+        ]
+        if non_trivial:
+            times = sorted({int(iv.get("time", 0)) for iv in non_trivial})
+            return (
+                False,
+                f"movement-altering interventions (capacity<1 / lockdown / "
+                f"selfiso) scheduled at t={times}",
+            )
+        return True, ""
+
     def build_context(self, loaded: LoadedSimulationData) -> SimulationContext:
         self._progress(
             0,
@@ -431,11 +477,23 @@ class SimulationRunner:
             intervention_weights=self.simdata["interventions"],
         )
         variants = self.simdata["variants"]
-        self._soa_engine = bool(os.environ.get("DELINEO_SOA_ENGINE"))
-        if self._soa_engine and (not self.aggregate_transmission or self.enable_logging):
-            raise RuntimeError(
-                "DELINEO_SOA_ENGINE requires aggregate_transmission and logging off"
-            )
+        # The engine is REQUESTED via env, but only ENGAGED when it can run this
+        # config correctly. Ineligible configs (movement interventions,
+        # multi-variant, logging/agg constraints) transparently fall back to the
+        # non-engine path instead of silently producing wrong results.
+        if _engine_requested():
+            eligible, reason = self._engine_eligibility(variants)
+            self._soa_engine = eligible
+            if not eligible:
+                logger.info(
+                    "SoA engine requested but not eligible (%s); falling back to "
+                    "the non-engine path for correct results.",
+                    reason,
+                )
+            else:
+                logger.info("SoA engine engaged (eligible config).")
+        else:
+            self._soa_engine = False
         # Single-variant engine mode derives infectious locations from occupancy,
         # so the event queue / _person_index (build_event_queue) is unnecessary.
         engine_no_queue = self._soa_engine and len(variants) == 1
@@ -714,10 +772,17 @@ class SimulationRunner:
                             )
 
                 if self._soa_engine:
+                    # Defensive net: _engine_eligibility already excludes
+                    # movement interventions before the engine is engaged, and an
+                    # eligible (single-variant) engine run never reaches this
+                    # queue path (it uses _run_queue_engine). If this ever fires,
+                    # eligibility has a bug — fail loudly rather than silently drop
+                    # the intervention.
                     if not _trivial_movement_interventions(interventions):
                         raise RuntimeError(
-                            "DELINEO_SOA_ENGINE does not support movement-altering "
-                            "interventions (capacity<1 / lockdown / selfiso)"
+                            "SoA engine reached a movement-altering intervention "
+                            "despite eligibility gating (capacity<1 / lockdown / "
+                            "selfiso) — this is a bug in _engine_eligibility"
                         )
                     with self._timed("run_queue/apply_movement"):
                         if context.simulator.membership.apply_movement(ts):

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -87,6 +87,10 @@ class SimulationContext:
     # SoA engine mode: the current-timestep OccupancyView, rebuilt after each
     # vectorized movement and read by the snapshot + transmission kernel.
     occupancy: object = None
+    # SoA engine mode: person indices whose state value changed in this step's
+    # update_people_states. update_variant_tracking consumes it to update only
+    # the changed entries instead of rewriting the whole infected map each step.
+    states_changed_idx: list = field(default_factory=list)
 
 
 def _trivial_movement_interventions(interventions: dict) -> bool:
@@ -531,19 +535,31 @@ class SimulationRunner:
                 self.simdata["initial_infected_count"],
             )
 
+        # variant_infected accumulates the per-variant {pid: state} map that is
+        # snapshotted each step. In engine mode it is maintained incrementally
+        # (update_variant_tracking only touches people who changed this step), so
+        # the initial seeds must be written here at build — the incremental path
+        # would otherwise miss seeds that don't transition by the first timestep.
+        susceptible = InfectionState.SUSCEPTIBLE
+        variant_infected = {variant: {} for variant in variants}
         if self._soa_engine or os.environ.get("DELINEO_SOA_SHADOW"):
             self._attach_membership_shadow(simulator, loaded.people_data)
         if self._soa_engine:
             store = simulator.membership
             store.set_person_refs(simulator.get_person)
             # Seed infections were scheduled before the store existed; backfill
-            # the ever-infected mask + state mirror from the already-infected set.
+            # the ever-infected mask + state mirror from the already-infected set,
+            # and seed variant_infected with their build-time (t=0) states.
             mirror_variant = variants[0]
             for pid in infection_manager.infected:
                 store.mark_infected(pid)
                 person = simulator.people.get(pid)
                 if person is not None:
                     self._mirror_person_state(store, person, mirror_variant)
+                    for disease in variants:
+                        state = person.states.get(disease, susceptible)
+                        if state != susceptible:
+                            variant_infected[disease][person.id] = int(state.value)
             with self._timed("build_context/precompute_movement"):
                 store.precompute_movement(loaded.patterns_data, self.simdata["length"])
             # Per-room Wells-Riley base quanta (ventilation is static), so the
@@ -563,7 +579,7 @@ class SimulationRunner:
             infection_manager=infection_manager,
             snapshot_writer=SimulationSnapshotWriter(self.output_dir),
             variants=variants,
-            variant_infected={variant: {} for variant in variants},
+            variant_infected=variant_infected,
             people_with_timelines=seeded_population.people_with_timelines,
             max_length=self.simdata["length"],
             last_movement_ts=-simulator.timestep,
@@ -830,11 +846,23 @@ class SimulationRunner:
             pstate = context.simulator.membership.pstate
             variant = context.variants[0]
             susceptible = InfectionState.SUSCEPTIBLE
+            time = int(ts_str)
+            changed = context.states_changed_idx
+            changed.clear()
             for person in context.people_with_timelines:
+                # update_state itself early-exits between timeline boundaries; do
+                # the same check here so non-transitioning people cost nothing and
+                # the per-person numpy scalar write (the bulk of this stage at
+                # saturation) is skipped unless the state value actually changed.
+                # Byte-identical to calling update_state + writing pstate for all.
+                if time < person._next_transition_time:
+                    continue
                 person.update_state(ts_str, context.variants)
-                pstate[person._soa_idx] = int(
-                    person.states.get(variant, susceptible).value
-                )
+                idx = person._soa_idx
+                value = int(person.states.get(variant, susceptible).value)
+                if value != pstate[idx]:
+                    pstate[idx] = value
+                    changed.append(idx)
         else:
             for person in context.people_with_timelines:
                 person.update_state(ts_str, context.variants)
@@ -842,13 +870,22 @@ class SimulationRunner:
     def update_variant_tracking(self, context: SimulationContext) -> None:
         susceptible = InfectionState.SUSCEPTIBLE
         if self._soa_engine:
-            # No event queue/registry in engine mode; people_with_timelines is
-            # the ever-infected set (a superset of the registry).
-            for person in context.people_with_timelines:
-                for disease in context.variants:
+            # Incremental: only people whose state value changed in this step's
+            # update_people_states need their variant_infected entry refreshed.
+            # Unchanged entries are already correct from the step they last
+            # changed, and newly-infected people are written directly by the
+            # transmission kernel (variant_bucket[...]). Byte-identical to
+            # rewriting the whole ever-infected map every step, but O(changed)
+            # instead of O(ever-infected).
+            idx_to_person = context.simulator.membership.idx_to_person
+            variant_infected = context.variant_infected
+            variants = context.variants
+            for idx in context.states_changed_idx:
+                person = idx_to_person[idx]
+                for disease in variants:
                     state = person.states.get(disease, susceptible)
                     if state != susceptible:
-                        context.variant_infected[disease][person.id] = int(state.value)
+                        variant_infected[disease][person.id] = int(state.value)
             return
         for pid_str in context.event_queue.registry:
             person = context.simulator.get_person(pid_str)

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -488,8 +488,14 @@ class SimulationRunner:
         """
         from .membership import MembershipStore
 
-        location_keys = [(h.id, True) for h in simulator.households.values()]
-        location_keys += [(f.id, False) for f in simulator.facilities.values()]
+        # Order homes then places, each by numeric id, to match the Next
+        # sim-processor's homeIds/placeIds (sorted by Number). This makes the
+        # numeric snapshot's positional [count, infected] arrays line up with the
+        # frontend's map-cache slots without an id lookup.
+        homes = sorted(simulator.households.values(), key=lambda h: int(h.id))
+        places = sorted(simulator.facilities.values(), key=lambda f: int(f.id))
+        location_keys = [(h.id, True) for h in homes]
+        location_keys += [(f.id, False) for f in places]
         store = MembershipStore(list(people_data.keys()), location_keys)
 
         for loc_id, is_hh in location_keys:

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -430,17 +430,29 @@ class SimulationRunner:
             enable_logging=self.enable_logging,
             intervention_weights=self.simdata["interventions"],
         )
+        variants = self.simdata["variants"]
+        self._soa_engine = bool(os.environ.get("DELINEO_SOA_ENGINE"))
+        if self._soa_engine and (not self.aggregate_transmission or self.enable_logging):
+            raise RuntimeError(
+                "DELINEO_SOA_ENGINE requires aggregate_transmission and logging off"
+            )
+        # Single-variant engine mode derives infectious locations from occupancy,
+        # so the event queue / _person_index (build_event_queue) is unnecessary.
+        engine_no_queue = self._soa_engine and len(variants) == 1
+
         with self._timed("build_context/build_locations"):
             build_locations(simulator, loaded.homes_data, loaded.places_data)
-        with self._timed("build_context/build_event_queue"):
-            event_queue = build_event_queue(loaded.patterns_data, self.simdata["length"])
+        if engine_no_queue:
+            event_queue = None
+        else:
+            with self._timed("build_context/build_event_queue"):
+                event_queue = build_event_queue(loaded.patterns_data, self.simdata["length"])
 
         self._progress(
             0,
             1,
             f"Initializing {len(loaded.people_data)} people & seeding infections...",
         )
-        variants = self.simdata["variants"]
         infection_manager = InfectionManager(
             infected_ids=[],
             disease_name=self.simdata["disease_name"],
@@ -458,11 +470,6 @@ class SimulationRunner:
                 self.simdata["initial_infected_count"],
             )
 
-        self._soa_engine = bool(os.environ.get("DELINEO_SOA_ENGINE"))
-        if self._soa_engine and (not self.aggregate_transmission or self.enable_logging):
-            raise RuntimeError(
-                "DELINEO_SOA_ENGINE requires aggregate_transmission and logging off"
-            )
         if self._soa_engine or os.environ.get("DELINEO_SOA_SHADOW"):
             self._attach_membership_shadow(simulator, loaded.people_data)
         if self._soa_engine:
@@ -595,6 +602,9 @@ class SimulationRunner:
                 )
 
     def run_queue(self, context: SimulationContext) -> None:
+        if context.event_queue is None:
+            self._run_queue_engine(context)
+            return
         self._progress(0, context.max_length, "Running simulation...")
         logger.info(
             "Starting queue-based simulation (queue size: %d)",
@@ -624,6 +634,53 @@ class SimulationRunner:
         self._progress(context.max_length, context.max_length, "Simulation complete, writing output...")
         logger.info("SIMULATION COMPLETE (%d timesteps processed)", context.processed_count)
 
+        if _perf_timings_enabled():
+            for label in sorted(self._perf_accum):
+                print(f"[perf] {label}: {self._perf_accum[label]:.3f}s", flush=True)
+
+    def _run_queue_engine(self, context: SimulationContext) -> None:
+        """Timestep-driven loop for single-variant engine mode (no event queue).
+
+        Movement comes from the precomputed per-timestep scatter; transmission
+        runs every step (vectorized, a no-op when no one is infectious). The
+        event queue and its _person_index are not built at all.
+        """
+        sim = context.simulator
+        store = sim.membership
+        self._progress(0, context.max_length, "Running simulation...")
+        logger.info("Starting timestep-driven engine simulation")
+
+        ts = sim.timestep
+        while ts <= context.max_length:
+            self._progress(ts, context.max_length)
+            ts_str = str(ts)
+            context.processed_count += 1
+
+            if ts in store._move:
+                interventions = sim.get_interventions(ts_str)
+                with self._timed("run_queue/update_people_states"):
+                    self.update_people_states(context, ts_str)
+                if interventions is not context.last_interventions:
+                    with self._timed("run_queue/apply_interventions"):
+                        context.last_interventions = interventions
+                        for person in sim.people.values():
+                            apply_person_interventions(sim, person, interventions, ts_str)
+                with self._timed("run_queue/apply_movement"):
+                    store.apply_movement(ts)
+
+            with self._timed("run_queue/process_infections"):
+                self._vectorized_transmission(context, ts)
+            with self._timed("run_queue/update_variant_tracking"):
+                self.update_variant_tracking(context)
+            with self._timed("run_queue/write_snapshot"):
+                self.write_snapshot(context, ts_str)
+            context.last_movement_ts = ts
+            ts += sim.timestep
+
+        self._progress(
+            context.max_length, context.max_length, "Simulation complete, writing output..."
+        )
+        logger.info("SIMULATION COMPLETE (%d timesteps processed)", context.processed_count)
         if _perf_timings_enabled():
             for label in sorted(self._perf_accum):
                 print(f"[perf] {label}: {self._perf_accum[label]:.3f}s", flush=True)
@@ -711,13 +768,23 @@ class SimulationRunner:
                 person.update_state(ts_str, context.variants)
 
     def update_variant_tracking(self, context: SimulationContext) -> None:
+        susceptible = InfectionState.SUSCEPTIBLE
+        if self._soa_engine:
+            # No event queue/registry in engine mode; people_with_timelines is
+            # the ever-infected set (a superset of the registry).
+            for person in context.people_with_timelines:
+                for disease in context.variants:
+                    state = person.states.get(disease, susceptible)
+                    if state != susceptible:
+                        context.variant_infected[disease][person.id] = int(state.value)
+            return
         for pid_str in context.event_queue.registry:
             person = context.simulator.get_person(pid_str)
             if not person:
                 continue
             for disease in context.variants:
-                state = person.states.get(disease, InfectionState.SUSCEPTIBLE)
-                if state != InfectionState.SUSCEPTIBLE:
+                state = person.states.get(disease, susceptible)
+                if state != susceptible:
                     context.variant_infected[disease][pid_str] = int(state.value)
 
     def write_snapshot(self, context: SimulationContext, ts_str: str) -> None:

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -650,6 +650,10 @@ class SimulationRunner:
         self._progress(0, context.max_length, "Running simulation...")
         logger.info("Starting timestep-driven engine simulation")
 
+        # Ship the per-person decode tables once, before any timestep, so the
+        # streaming per-person map routes (person-path) read `meta` first.
+        context.snapshot_writer.write_meta(store.movement_meta())
+
         ts = sim.timestep
         while ts <= context.max_length:
             self._progress(ts, context.max_length)
@@ -808,7 +812,13 @@ class SimulationRunner:
             if self._soa_engine:
                 # Numeric per-location [count, infected] (map-cache shape) — the
                 # ~50x snapshot win. Consumed directly by the Next sim-processor.
-                movement = context.simulator.membership.movement_snapshot_numeric()
+                store = context.simulator.membership
+                movement = store.movement_snapshot_numeric()
+                # Per-person current location (person index -> location index).
+                # Decoded via the one-time `meta` entry so the per-person map
+                # views (people-map, person-path) can reconstruct who-is-where
+                # without the engine ever materializing pid lists.
+                movement["loc"] = store.person_loc.tolist()
             else:
                 movement = build_movement_snapshot(context.simulator)
         with self._timed("write_snapshot/build_infection"):

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -286,6 +286,15 @@ def apply_person_interventions(
         )
         person.set_vaccinated(VaccinationState(doses))
 
+    # Keep the SoA scalar mirror in sync when masking/vaccination changed.
+    store = getattr(simulator, "membership", None)
+    if store is not None and person._soa_idx >= 0:
+        i = person._soa_idx
+        store.masked[i] = person.masked
+        if person.vaccination_status:
+            store.vax_trans_factor[i] = 1.0 - get_vaccination_protection(person, "transmission")
+            store.vax_inf_protection[i] = get_vaccination_protection(person, "infection")
+
 
 class SimulationRunner:
     def __init__(
@@ -458,9 +467,13 @@ class SimulationRunner:
             store = simulator.membership
             store.set_person_refs(simulator.get_person)
             # Seed infections were scheduled before the store existed; backfill
-            # the ever-infected mask from the already-infected set.
+            # the ever-infected mask + state mirror from the already-infected set.
+            mirror_variant = variants[0]
             for pid in infection_manager.infected:
                 store.mark_infected(pid)
+                person = simulator.people.get(pid)
+                if person is not None:
+                    self._mirror_person_state(store, person, mirror_variant)
             with self._timed("build_context/precompute_movement"):
                 store.precompute_movement(loaded.patterns_data, self.simdata["length"])
 
@@ -514,6 +527,40 @@ class SimulationRunner:
         self._soa_shadow = bool(os.environ.get("DELINEO_SOA_SHADOW"))
         self._shadow_mismatches = 0
         self._shadow_checks = 0
+
+    def _mirror_person_state(self, store, person, variant: str) -> None:
+        """Mirror one person's hot scalars (state, masked, vax factors) into the
+        store arrays. The vectorized kernel (stage 2) reads these instead of the
+        Person objects. Single-variant; multidisease keeps the per-person kernel.
+        """
+        i = person._soa_idx
+        if i < 0:
+            return
+        store.pstate[i] = int(person.states.get(variant, InfectionState.SUSCEPTIBLE).value)
+        store.masked[i] = person.masked
+        if person.vaccination_status:
+            store.vax_trans_factor[i] = 1.0 - get_vaccination_protection(person, "transmission")
+            store.vax_inf_protection[i] = get_vaccination_protection(person, "infection")
+        else:
+            store.vax_trans_factor[i] = 1.0
+            store.vax_inf_protection[i] = 0.0
+
+    def _shadow_validate_state_mirror(self, context) -> None:
+        """Assert the mirrored arrays still match the Person objects (debug)."""
+        store = context.simulator.membership
+        variant = context.variants[0]
+        susceptible = InfectionState.SUSCEPTIBLE
+        self._shadow_checks += 1
+        for person in context.simulator.people.values():
+            i = person._soa_idx
+            want = int(person.states.get(variant, susceptible).value)
+            if store.pstate[i] != want or bool(store.masked[i]) != bool(person.masked):
+                self._shadow_mismatches += 1
+                logger.warning(
+                    "SOA state-mirror mismatch pid=%s: pstate=%d want=%d masked=%s/%s",
+                    person.id, store.pstate[i], want, bool(store.masked[i]), person.masked,
+                )
+                return
 
     def _shadow_validate_occupancy(self, simulator) -> None:
         """Assert the OccupancyView reproduces the dict membership (order incl.)."""
@@ -638,8 +685,18 @@ class SimulationRunner:
     def update_people_states(self, context: SimulationContext, ts_str: str) -> None:
         # people_with_timelines holds Person refs directly (see PopulationBuildResult);
         # iterate them without a simulator.get_person(pid) lookup per call.
-        for person in context.people_with_timelines:
-            person.update_state(ts_str, context.variants)
+        if self._soa_engine:
+            pstate = context.simulator.membership.pstate
+            variant = context.variants[0]
+            susceptible = InfectionState.SUSCEPTIBLE
+            for person in context.people_with_timelines:
+                person.update_state(ts_str, context.variants)
+                pstate[person._soa_idx] = int(
+                    person.states.get(variant, susceptible).value
+                )
+        else:
+            for person in context.people_with_timelines:
+                person.update_state(ts_str, context.variants)
 
     def update_variant_tracking(self, context: SimulationContext) -> None:
         for pid_str in context.event_queue.registry:
@@ -661,7 +718,12 @@ class SimulationRunner:
                     context.simulator.logger.log_location_state(facility, ts_str)
 
         if self._soa_shadow:
-            self._shadow_validate_occupancy(context.simulator)
+            if self._soa_engine:
+                # Engine mode drives movement via arrays (dicts are stale), so
+                # validate the state mirror, not the dict-vs-occupancy match.
+                self._shadow_validate_state_mirror(context)
+            else:
+                self._shadow_validate_occupancy(context.simulator)
 
         with self._timed("write_snapshot/build_movement"):
             if self._soa_engine:

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -7,6 +7,8 @@ import math
 import os
 import random
 import time
+
+import numpy as np
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
@@ -476,6 +478,16 @@ class SimulationRunner:
                     self._mirror_person_state(store, person, mirror_variant)
             with self._timed("build_context/precompute_movement"):
                 store.precompute_movement(loaded.patterns_data, self.simdata["length"])
+            # Per-room Wells-Riley base quanta (ventilation is static), so the
+            # vectorized kernel needs no per-room work at runtime.
+            exposure_hours = simulator.timestep / 60.0
+            base_q = np.empty(store.num_locations, dtype=np.float64)
+            for loc_idx, (loc_id, is_hh) in enumerate(store.idx_to_loc):
+                place = simulator.get_location(loc_id, is_hh)
+                base_q[loc_idx] = (20.0 * 0.5 * exposure_hours) / self._ventilation_rate(
+                    place, is_hh
+                )
+            store.base_quanta = base_q
 
         return SimulationContext(
             simulator=simulator,
@@ -738,9 +750,95 @@ class SimulationRunner:
             context.snapshot_writer.write(ts_str, movement, infection)
 
     def process_infections_at_timestep(self, context: SimulationContext, timestep: int) -> None:
+        if self._soa_engine and len(context.variants) == 1:
+            # The queue still gates which timesteps have any infectious presence;
+            # drain it to advance, then run one vectorized pass over all rooms.
+            had_event = False
+            while context.event_queue and context.event_queue.peek()[0] == timestep:
+                context.event_queue.pop()
+                had_event = True
+            if had_event:
+                with self._timed("infection_event/aggregate_iteration"):
+                    self._vectorized_transmission(context, timestep)
+            return
         while context.event_queue and context.event_queue.peek()[0] == timestep:
             ts, poi_id, is_household = context.event_queue.pop()
             self.process_infection_event(context, ts, poi_id, is_household)
+
+    def _vectorized_transmission(self, context: SimulationContext, ts: int) -> None:
+        """Single-variant well-mixed Wells-Riley over all rooms at once.
+
+        Equivalent to running _aggregate_transmission_event per room, but as
+        numpy array ops: emission summed per room with bincount, then one
+        vectorized infection draw per susceptible. RNG source differs (numpy vs
+        python per-pair) -> ensemble-validated, not byte-identical.
+        """
+        store = context.simulator.membership
+        variant = context.variants[0]
+        pstate = store.pstate
+        person_loc = store.person_loc
+        masked = store.masked
+
+        INFECTIOUS = int(InfectionState.INFECTIOUS.value)
+        INVISIBLE = int(
+            (InfectionState.HOSPITALIZED | InfectionState.RECOVERED | InfectionState.REMOVED).value
+        )
+        placed = person_loc >= 0
+        infectious = placed & ((pstate & INFECTIOUS) != 0)
+        if not infectious.any():
+            return
+
+        # Emission weight per infector, summed per room (cheap O(N) numpy).
+        inf_w = np.where(masked, 0.30, 1.0) * store.vax_trans_factor
+        emit = np.where(infectious, inf_w, 0.0)
+        W = np.bincount(
+            person_loc[placed], weights=emit[placed], minlength=store.num_locations
+        )
+
+        # Restrict the expensive trials (exp + RNG + scheduling) to actually
+        # exposed susceptibles — those placed in a room with infectors. This keeps
+        # the kernel cheap at low prevalence (few eligible) and at saturation
+        # (numpy), instead of drawing for all N every timestep.
+        loc = np.where(placed, person_loc, 0)
+        room_W = W[loc]
+        eligible = placed & (pstate == 0) & ((pstate & INVISIBLE) == 0) & (room_W > 0.0)
+        elig_idx = np.nonzero(eligible)[0]
+        if elig_idx.size == 0:
+            return
+
+        intake = np.where(masked[elig_idx], 0.50, 1.0) * (
+            1.0 - store.vax_inf_protection[elig_idx]
+        )
+        mean_quanta = store.base_quanta[loc[elig_idx]] * room_W[elig_idx] * intake
+        prob = 1.0 - np.exp(-mean_quanta)
+        draws = np.random.random(elig_idx.size)
+        hits = elig_idx[draws < prob]
+        if hits.size == 0:
+            return
+
+        infection_mgr = context.infection_manager
+        infected_set = infection_mgr.infected
+        idx_to_person = store.idx_to_person
+        variant_bucket = context.variant_infected[variant]
+        infected_state_value = int(
+            (InfectionState.INFECTED | InfectionState.INFECTIOUS).value
+        )
+        for i in hits:
+            target = idx_to_person[i]
+            target_id = target.id
+            infected_set.add(target_id)
+            infection_mgr.schedule_infection(
+                context.simulator,
+                context.event_queue,
+                target,
+                variant,
+                ts,
+                context.people_with_timelines,
+            )
+            variant_bucket[target_id] = infected_state_value
+            context.simulator.log_event(
+                "log_infection_event", target, None, None, variant, ts
+            )
 
     def _ventilation_rate(self, place, is_household: bool) -> float:
         """Wells-Riley ventilation term Q (m^3/hr).

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -560,6 +560,7 @@ class SimulationRunner:
                         state = person.states.get(disease, susceptible)
                         if state != susceptible:
                             variant_infected[disease][person.id] = int(state.value)
+                            store.snap_state[person._soa_idx] = int(state.value)
             with self._timed("build_context/precompute_movement"):
                 store.precompute_movement(loaded.patterns_data, self.simdata["length"])
             # Per-room Wells-Riley base quanta (ventilation is static), so the
@@ -880,12 +881,14 @@ class SimulationRunner:
             idx_to_person = context.simulator.membership.idx_to_person
             variant_infected = context.variant_infected
             variants = context.variants
+            snap_state = context.simulator.membership.snap_state
             for idx in context.states_changed_idx:
                 person = idx_to_person[idx]
                 for disease in variants:
                     state = person.states.get(disease, susceptible)
                     if state != susceptible:
                         variant_infected[disease][person.id] = int(state.value)
+                        snap_state[idx] = int(state.value)
             return
         for pid_str in context.event_queue.registry:
             person = context.simulator.get_person(pid_str)
@@ -924,6 +927,10 @@ class SimulationRunner:
                 # views (people-map, person-path) can reconstruct who-is-where
                 # without the engine ever materializing pid lists.
                 movement["loc"] = store.person_loc.tolist()
+                # Per-place [infected, recovered] dot counts (places order), so
+                # the Cases-map dot bake reads them directly instead of
+                # reconstructing per person from `loc` + the sim snapshot.
+                movement["pdots"] = store.place_dot_counts()
             else:
                 movement = build_movement_snapshot(context.simulator)
         with self._timed("write_snapshot/build_infection"):
@@ -1018,6 +1025,7 @@ class SimulationRunner:
                 context.people_with_timelines,
             )
             variant_bucket[target_id] = infected_state_value
+            store.snap_state[i] = infected_state_value
             context.simulator.log_event(
                 "log_infection_event", target, None, None, variant, ts
             )

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -70,6 +70,19 @@ class SimulationContext:
     last_movement_ts: int = 0
     last_interventions: Optional[dict] = None
     initial_infected_ids: list[str] = field(default_factory=list)
+    # SoA engine mode: the current-timestep OccupancyView, rebuilt after each
+    # vectorized movement and read by the snapshot + transmission kernel.
+    occupancy: object = None
+
+
+def _trivial_movement_interventions(interventions: dict) -> bool:
+    """True when no intervention redirects movement (so a pure person_loc
+    scatter equals move_people). Masking/vaccination don't move people."""
+    return (
+        float(interventions.get("capacity", 1.0)) >= 1.0
+        and float(interventions.get("lockdown", 0.0)) <= 0.0
+        and float(interventions.get("selfiso", 0.0)) <= 0.0
+    )
 
 
 def normalize_simdata(simdata: dict) -> dict:
@@ -298,6 +311,8 @@ class SimulationRunner:
             float(INFECTION_MODEL.get("area_clamp_max", 70000.0)),
         )
         self._perf_accum: dict[str, float] = {}
+        self._soa_engine: bool = False
+        self._soa_shadow: bool = False
 
     @contextlib.contextmanager
     def _timed(self, label: str):
@@ -432,8 +447,18 @@ class SimulationRunner:
                 self.simdata["initial_infected_count"],
             )
 
-        if os.environ.get("DELINEO_SOA_SHADOW"):
+        self._soa_engine = bool(os.environ.get("DELINEO_SOA_ENGINE"))
+        if self._soa_engine and (not self.aggregate_transmission or self.enable_logging):
+            raise RuntimeError(
+                "DELINEO_SOA_ENGINE requires aggregate_transmission and logging off"
+            )
+        if self._soa_engine or os.environ.get("DELINEO_SOA_SHADOW"):
             self._attach_membership_shadow(simulator, loaded.people_data)
+        if self._soa_engine:
+            store = simulator.membership
+            store.set_person_refs(simulator.get_person)
+            with self._timed("build_context/precompute_movement"):
+                store.precompute_movement(loaded.patterns_data, self.simdata["length"])
 
         return SimulationContext(
             simulator=simulator,
@@ -476,6 +501,7 @@ class SimulationRunner:
                 store.note_placement(pid, facility._loc_idx)
 
         simulator.membership = store
+        self._soa_shadow = bool(os.environ.get("DELINEO_SOA_SHADOW"))
         self._shadow_mismatches = 0
         self._shadow_checks = 0
 
@@ -557,7 +583,16 @@ class SimulationRunner:
                                 ts_str,
                             )
 
-                if isinstance(timestep_data, dict):
+                if self._soa_engine:
+                    if not _trivial_movement_interventions(interventions):
+                        raise RuntimeError(
+                            "DELINEO_SOA_ENGINE does not support movement-altering "
+                            "interventions (capacity<1 / lockdown / selfiso)"
+                        )
+                    with self._timed("run_queue/apply_movement"):
+                        if context.simulator.membership.apply_movement(ts):
+                            context.occupancy = None  # rebuilt lazily below
+                elif isinstance(timestep_data, dict):
                     if "homes" in timestep_data:
                         with self._timed("run_queue/move_people_home"):
                             move_people(
@@ -576,6 +611,10 @@ class SimulationRunner:
                                 ts_str,
                                 interventions,
                             )
+
+            if self._soa_engine and context.occupancy is None:
+                with self._timed("run_queue/build_occupancy"):
+                    context.occupancy = context.simulator.membership.occupancy_view()
 
             with self._timed("run_queue/update_variant_tracking"):
                 self.update_variant_tracking(context)
@@ -611,11 +650,14 @@ class SimulationRunner:
                 if facility.population:
                     context.simulator.logger.log_location_state(facility, ts_str)
 
-        if getattr(context.simulator, "membership", None) is not None:
+        if self._soa_shadow:
             self._shadow_validate_occupancy(context.simulator)
 
         with self._timed("write_snapshot/build_movement"):
-            movement = build_movement_snapshot(context.simulator)
+            if self._soa_engine:
+                movement = context.simulator.membership.movement_snapshot(context.occupancy)
+            else:
+                movement = build_movement_snapshot(context.simulator)
         with self._timed("write_snapshot/build_infection"):
             infection = build_infection_snapshot(context.variant_infected)
         with self._timed("write_snapshot/writer_write"):
@@ -656,10 +698,24 @@ class SimulationRunner:
             return
 
         place = context.simulator.get_location(str(poi_id), is_household)
-        if not place or not place.population:
+        if not place:
             return
 
-        snapshot = list(place.population.values())
+        if self._soa_engine:
+            store = context.simulator.membership
+            loc_idx = store.loc_to_idx.get((str(poi_id), is_household))
+            if loc_idx is None:
+                return
+            occ = context.occupancy.occupants_of(loc_idx)
+            if len(occ) == 0:
+                return
+            idx_to_person = store.idx_to_person
+            snapshot = [idx_to_person[i] for i in occ]
+        else:
+            if not place.population:
+                return
+            snapshot = list(place.population.values())
+
         infectious_people = [person for person in snapshot if person.is_infectious()]
         if not infectious_people:
             return
@@ -833,10 +889,24 @@ class SimulationRunner:
         "aggregate_transmission" field.
         """
         place = context.simulator.get_location(str(poi_id), is_household)
-        if not place or not place.population:
+        if not place:
             return
 
-        snapshot = list(place.population.values())
+        if self._soa_engine:
+            store = context.simulator.membership
+            loc_idx = store.loc_to_idx.get((str(poi_id), is_household))
+            if loc_idx is None:
+                return
+            occ = context.occupancy.occupants_of(loc_idx)
+            if len(occ) == 0:
+                return
+            idx_to_person = store.idx_to_person
+            snapshot = [idx_to_person[i] for i in occ]
+        else:
+            if not place.population:
+                return
+            snapshot = list(place.population.values())
+
         infectious_people = [person for person in snapshot if person.is_infectious()]
         if not infectious_people:
             return

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -457,6 +457,10 @@ class SimulationRunner:
         if self._soa_engine:
             store = simulator.membership
             store.set_person_refs(simulator.get_person)
+            # Seed infections were scheduled before the store existed; backfill
+            # the ever-infected mask from the already-infected set.
+            for pid in infection_manager.infected:
+                store.mark_infected(pid)
             with self._timed("build_context/precompute_movement"):
                 store.precompute_movement(loaded.patterns_data, self.simdata["length"])
 
@@ -655,7 +659,9 @@ class SimulationRunner:
 
         with self._timed("write_snapshot/build_movement"):
             if self._soa_engine:
-                movement = context.simulator.membership.movement_snapshot(context.occupancy)
+                # Numeric per-location [count, infected] (map-cache shape) — the
+                # ~50x snapshot win. Consumed directly by the Next sim-processor.
+                movement = context.simulator.membership.movement_snapshot_numeric()
             else:
                 movement = build_movement_snapshot(context.simulator)
         with self._timed("write_snapshot/build_infection"):

--- a/simulator/snapshots.py
+++ b/simulator/snapshots.py
@@ -34,6 +34,18 @@ class SimulationSnapshotWriter:
         self._patterns_json[ts_str] = movement
         self._simdata_json[ts_str] = result
 
+    def write_meta(self, meta: dict) -> None:
+        """Write a one-time, non-timestep ``meta`` entry into the patterns file.
+
+        Timestep consumers key by numeric timestep and skip non-numeric keys, so
+        this rides alongside the per-timestep snapshots in the same file. Used by
+        the SoA engine to ship the per-person ``loc`` decode tables (see
+        ``MembershipStore.movement_meta``)."""
+        if self._patterns_writer:
+            self._patterns_writer.add("meta", meta)
+        elif self._patterns_json is not None:
+            self._patterns_json["meta"] = meta
+
     def close(self) -> None:
         if self._simdata_writer:
             self._simdata_writer.close()

--- a/tests/test_engine_eligibility.py
+++ b/tests/test_engine_eligibility.py
@@ -8,7 +8,7 @@ back to the non-engine path) instead of silently producing wrong results.
 import unittest
 from unittest import mock
 
-from simulator.runner import SimulationRunner, _engine_requested
+from simulator.runner import SimulationRunner, _engine_disabled
 
 
 def _iv(time=0, mask=0.0, vaccine=0.0, capacity=1.0, lockdown=0.0, selfiso=0.0):
@@ -79,20 +79,23 @@ class EngineEligibilityTest(unittest.TestCase):
         self.assertIn("aggregate", reason)
 
 
-class EngineRequestedEnvParseTest(unittest.TestCase):
-    def test_truthy_values_request_engine(self):
-        for val in ("1", "true", "TRUE", "yes", "on"):
+class EngineKillSwitchEnvParseTest(unittest.TestCase):
+    """The engine is ON BY DEFAULT; DELINEO_SOA_ENGINE=0/false/off is the kill
+    switch. _engine_disabled() is True only for those explicit-off values."""
+
+    def test_off_values_disable_engine(self):
+        for val in ("0", "false", "FALSE", "no", "off"):
             with mock.patch.dict("os.environ", {"DELINEO_SOA_ENGINE": val}):
-                self.assertTrue(_engine_requested(), val)
+                self.assertTrue(_engine_disabled(), val)
 
-    def test_zero_disables_engine(self):
-        # the old bool(os.environ.get(...)) was truthy-on-presence: "0" wrongly ON
-        with mock.patch.dict("os.environ", {"DELINEO_SOA_ENGINE": "0"}):
-            self.assertFalse(_engine_requested())
-
-    def test_unset_disables_engine(self):
+    def test_unset_leaves_engine_on_by_default(self):
         with mock.patch.dict("os.environ", {}, clear=True):
-            self.assertFalse(_engine_requested())
+            self.assertFalse(_engine_disabled())
+
+    def test_on_values_leave_engine_enabled(self):
+        for val in ("1", "true", "yes", "on", ""):
+            with mock.patch.dict("os.environ", {"DELINEO_SOA_ENGINE": val}):
+                self.assertFalse(_engine_disabled(), val)
 
 
 if __name__ == "__main__":

--- a/tests/test_engine_eligibility.py
+++ b/tests/test_engine_eligibility.py
@@ -1,0 +1,99 @@
+"""Unit tests for SoA-engine eligibility routing + graceful fallback.
+
+The vectorized engine cannot apply movement-altering interventions
+(capacity<1 / lockdown / selfiso) or run multi-variant correctly, so
+`_engine_eligibility` must report those configs ineligible (→ the runner falls
+back to the non-engine path) instead of silently producing wrong results.
+"""
+import unittest
+from unittest import mock
+
+from simulator.runner import SimulationRunner, _engine_requested
+
+
+def _iv(time=0, mask=0.0, vaccine=0.0, capacity=1.0, lockdown=0.0, selfiso=0.0):
+    return {"time": time, "mask": mask, "vaccine": vaccine,
+            "capacity": capacity, "lockdown": lockdown, "selfiso": selfiso}
+
+
+def _runner(interventions, variants=("Delta",), enable_logging=False, agg=True):
+    simdata = {
+        "czone_id": 1, "length": 100, "interventions": list(interventions),
+        "variants": list(variants), "aggregate_transmission": agg,
+    }
+    return SimulationRunner(simdata=simdata, enable_logging=enable_logging,
+                            data_loader=lambda *a, **k: ({}, {}))
+
+
+class EngineEligibilityTest(unittest.TestCase):
+    def _eligible(self, runner):
+        return runner._engine_eligibility(runner.simdata["variants"])
+
+    def test_clean_single_variant_run_is_eligible(self):
+        ok, reason = self._eligible(_runner([_iv()]))
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+
+    def test_no_interventions_is_eligible(self):
+        ok, _ = self._eligible(_runner([]))
+        self.assertTrue(ok)
+
+    def test_mask_and_vaccine_only_is_eligible(self):
+        # person-level interventions don't move people → engine applies them
+        ok, _ = self._eligible(_runner([_iv(mask=0.8, vaccine=0.5)]))
+        self.assertTrue(ok)
+
+    def test_lockdown_is_ineligible(self):
+        ok, reason = self._eligible(_runner([_iv(lockdown=0.7)]))
+        self.assertFalse(ok)
+        self.assertIn("movement", reason)
+
+    def test_capacity_cap_is_ineligible(self):
+        ok, reason = self._eligible(_runner([_iv(capacity=0.5)]))
+        self.assertFalse(ok)
+        self.assertIn("movement", reason)
+
+    def test_selfiso_is_ineligible(self):
+        ok, _ = self._eligible(_runner([_iv(selfiso=0.3)]))
+        self.assertFalse(ok)
+
+    def test_movement_intervention_scheduled_after_t0_is_caught(self):
+        # a clean t=0 plus a lockdown that kicks in later must still be caught
+        ok, reason = self._eligible(_runner([_iv(time=0), _iv(time=5000, lockdown=0.4)]))
+        self.assertFalse(ok)
+        self.assertIn("5000", reason)
+
+    def test_multi_variant_is_ineligible(self):
+        ok, reason = self._eligible(_runner([_iv()], variants=("Delta", "Omicron")))
+        self.assertFalse(ok)
+        self.assertIn("multi-variant", reason)
+
+    def test_logging_on_is_ineligible(self):
+        ok, reason = self._eligible(_runner([_iv()], enable_logging=True))
+        self.assertFalse(ok)
+        self.assertIn("logging", reason)
+
+    def test_aggregate_off_is_ineligible(self):
+        ok, reason = self._eligible(_runner([_iv()], agg=False))
+        self.assertFalse(ok)
+        self.assertIn("aggregate", reason)
+
+
+class EngineRequestedEnvParseTest(unittest.TestCase):
+    def test_truthy_values_request_engine(self):
+        for val in ("1", "true", "TRUE", "yes", "on"):
+            with mock.patch.dict("os.environ", {"DELINEO_SOA_ENGINE": val}):
+                self.assertTrue(_engine_requested(), val)
+
+    def test_zero_disables_engine(self):
+        # the old bool(os.environ.get(...)) was truthy-on-presence: "0" wrongly ON
+        with mock.patch.dict("os.environ", {"DELINEO_SOA_ENGINE": "0"}):
+            self.assertFalse(_engine_requested())
+
+    def test_unset_disables_engine(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(_engine_requested())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engine_incremental_tracking.py
+++ b/tests/test_engine_incremental_tracking.py
@@ -1,0 +1,77 @@
+"""Regression guard for the incremental engine state/variant tracking (#2/#3).
+
+update_variant_tracking only refreshes people who changed state this step, so
+the initial seeds must be written into variant_infected at BUILD time — otherwise
+a seed that doesn't transition by the first timestep would be silently missing
+from the infection snapshot (the bug this guards).
+"""
+import unittest
+
+from simulator.runner import LoadedSimulationData, SimulationRunner
+from simulator.pap import InfectionState
+
+
+def _loaded(n=8):
+    # Engine mode sorts homes by int(id), so home ids must be numeric.
+    return LoadedSimulationData(
+        people_data={str(i): {"sex": i % 2, "age": 30 + i, "home": "1"} for i in range(n)},
+        homes_data={"1": {"cbg": "cbg-home"}},
+        places_data={},
+        patterns_data={
+            "60": {"homes": {"1": [str(i) for i in range(n)]}, "places": {}},
+            "120": {"homes": {"1": [str(i) for i in range(n)]}, "places": {}},
+        },
+    )
+
+
+def _simdata(seeds=3):
+    return {
+        "czone_id": 1, "length": 120, "randseed": False,
+        "initial_infected_count": seeds, "disease_name": "COVID-19",
+        "variants": ["Delta"], "dmp_mode": "off",
+        "interventions": [{"time": 0, "mask": 0.0, "vaccine": 0.0,
+                           "capacity": 1.0, "lockdown": 0.0, "selfiso": 0.0}],
+    }
+
+
+class EngineSeedTrackingTest(unittest.TestCase):
+    def test_engine_engages_for_eligible_run(self):
+        runner = SimulationRunner(_simdata(), enable_logging=False)
+        runner._seed_random()
+        runner.build_context(_loaded())
+        self.assertTrue(runner._soa_engine, "single-variant no-intervention run should use the engine")
+
+    def test_seeds_present_in_variant_infected_at_build(self):
+        # The incremental tracker would miss non-transitioning seeds without the
+        # build-time pre-population — this asserts they're there before step 1.
+        runner = SimulationRunner(_simdata(seeds=3), enable_logging=False)
+        runner._seed_random()
+        context = runner.build_context(_loaded())
+        variant = context.variants[0]
+        seeded = set(context.initial_infected_ids)
+        self.assertEqual(len(seeded), 3)
+        self.assertTrue(
+            seeded.issubset(set(context.variant_infected[variant])),
+            f"seeds {seeded} missing from variant_infected {set(context.variant_infected[variant])}",
+        )
+
+    def test_seeds_in_first_snapshot_after_run(self):
+        runner = SimulationRunner(_simdata(seeds=3), enable_logging=False)
+        runner._seed_random()
+        context = runner.build_context(_loaded())
+        runner.run_queue(context)
+        result = runner.finalize(context)
+        variant = context.variants[0]
+        seeded = set(context.initial_infected_ids)
+        first = result["result"]["60"][variant]  # infection snapshot at ts=60
+        self.assertTrue(
+            seeded.issubset(set(first)),
+            f"seeds {seeded} missing from first snapshot {set(first)}",
+        )
+        # every recorded value is a valid non-susceptible state
+        for state_val in first.values():
+            self.assertNotEqual(int(state_val) & ~int(InfectionState.SUSCEPTIBLE.value), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_membership.py
+++ b/tests/test_membership.py
@@ -1,0 +1,43 @@
+from simulator.membership import MembershipStore
+
+
+def _store():
+    pids = ["1", "2", "3", "4"]
+    locs = [("h1", True), ("h2", True), ("f1", False)]
+    return MembershipStore(pids, locs)
+
+
+def test_apply_movement_and_snapshot():
+    store = _store()
+    patterns = {
+        "60":  {"homes": {"h1": ["1", "2"], "h2": ["3", "4"]}, "places": {}},
+        "120": {"homes": {"h1": ["2"], "h2": ["4"]}, "places": {"f1": ["1", "3"]}},
+    }
+    store.precompute_movement(patterns, max_length=10080)
+
+    assert store.apply_movement(60)
+    snap = store.movement_snapshot()
+    assert snap["homes"] == {"h1": ["1", "2"], "h2": ["3", "4"]}
+    assert snap["places"] == {}
+
+    assert store.apply_movement(120)
+    snap = store.movement_snapshot()
+    assert snap["homes"] == {"h1": ["2"], "h2": ["4"]}
+    assert snap["places"] == {"f1": ["1", "3"]}
+
+
+def test_occupancy_indices():
+    store = _store()
+    store.precompute_movement(
+        {"120": {"homes": {"h1": ["2"], "h2": ["4"]}, "places": {"f1": ["1", "3"]}}},
+        max_length=10080,
+    )
+    store.apply_movement(120)
+    view = store.occupancy_view()
+    assert list(view.occupants_of(2)) == [0, 2]  # facility f1 -> persons 1,3
+    assert list(view.occupants_of(0)) == [1]      # household h1 -> person 2
+
+
+def test_apply_movement_unknown_ts_is_noop():
+    store = _store()
+    assert store.apply_movement(999) is False

--- a/tests/test_membership.py
+++ b/tests/test_membership.py
@@ -41,3 +41,19 @@ def test_occupancy_indices():
 def test_apply_movement_unknown_ts_is_noop():
     store = _store()
     assert store.apply_movement(999) is False
+
+
+def test_movement_snapshot_numeric():
+    store = _store()  # 4 people; locs h1,h2 (homes), f1 (place)
+    store.precompute_movement(
+        {"120": {"homes": {"h1": ["1", "2"], "h2": ["4"]}, "places": {"f1": ["3"]}}},
+        max_length=10080,
+    )
+    store.apply_movement(120)
+    store.mark_infected("2")  # person 2 infected, at h1
+    store.mark_infected("3")  # person 3 infected, at f1
+    num = store.movement_snapshot_numeric()
+    # homes order h1,h2: h1 has [1,2] count2 inf1; h2 has [4] count1 inf0
+    assert num["h"] == [2, 1, 1, 0]
+    # places order f1: [3] count1 inf1
+    assert num["p"] == [1, 1]

--- a/tests/test_patterns_codec.py
+++ b/tests/test_patterns_codec.py
@@ -1,0 +1,140 @@
+"""Tests for the DLNOPAT binary patterns format and the consumer fast path."""
+import json
+
+import numpy as np
+
+from simulator.patterns_codec import (
+    BinaryPatterns,
+    build_arrays_from_legacy,
+    decode_patterns_binary,
+    encode_patterns_binary,
+    is_binary_patterns,
+)
+from simulator.membership import MembershipStore
+
+
+# A tiny world where home id "1" and place id "1" collide (the reason locations
+# are keyed by (id, is_home)). Three people, two timesteps.
+PEOPLE = ["1", "2", "3"]
+PAPDATA = {
+    "people": {"1": {}, "2": {}, "3": {}},
+    "homes": {"1": {}, "2": {}},
+    "places": {"1": {}},
+}
+PATTERNS = {
+    "60": {"homes": {"1": ["1"], "2": ["2"]}, "places": {"1": ["3"]}},
+    "120": {"homes": {"1": ["1", "2"]}, "places": {"1": ["3"]}},
+}
+# Homes first, then places — the consumer's location index convention.
+LOCATION_KEYS = [("1", True), ("2", True), ("1", False)]
+
+
+def test_magic_sniff():
+    M, ts, pids, loc_ids, n_homes = build_arrays_from_legacy(PATTERNS, PAPDATA)
+    blob = encode_patterns_binary(M, ts, pids, loc_ids, n_homes)
+    assert is_binary_patterns(blob)
+    assert not is_binary_patterns(json.dumps(PATTERNS).encode("utf-8"))
+
+
+def test_round_trip_preserves_matrix():
+    M, ts, pids, loc_ids, n_homes = build_arrays_from_legacy(PATTERNS, PAPDATA)
+    bp = decode_patterns_binary(encode_patterns_binary(M, ts, pids, loc_ids, n_homes))
+    assert np.array_equal(bp.loc_matrix, M)
+    assert bp.ts_minutes == ts
+    assert bp.pids == pids
+    assert bp.loc_ids == loc_ids
+    assert bp.n_homes == n_homes
+    assert bp.loc_matrix.dtype == np.uint16
+
+
+def test_full_snapshot_required():
+    # Drop a person from one timestep -> not a full snapshot -> must fail loudly.
+    broken = {"60": {"homes": {"1": ["1"]}, "places": {}}}
+    try:
+        build_arrays_from_legacy(broken, PAPDATA)
+    except ValueError as e:
+        assert "full snapshot" in str(e)
+    else:
+        raise AssertionError("expected ValueError for non-full-snapshot patterns")
+
+
+def _person_loc_trace(store, patterns, max_length):
+    """Run precompute + apply for every timestep, return {ts: person_loc copy}."""
+    store.precompute_movement(patterns, max_length)
+    trace = {}
+    for ts in sorted(store._move):
+        store.apply_movement(ts)
+        trace[ts] = store.person_loc.copy()
+    return trace
+
+
+def test_binary_path_matches_json_path():
+    """The binary fast path must produce byte-identical person_loc to the JSON
+    loop at every timestep (representation-only change)."""
+    M, ts, pids, loc_ids, n_homes = build_arrays_from_legacy(PATTERNS, PAPDATA)
+    bp = decode_patterns_binary(encode_patterns_binary(M, ts, pids, loc_ids, n_homes))
+
+    json_store = MembershipStore(PEOPLE, LOCATION_KEYS)
+    bin_store = MembershipStore(PEOPLE, LOCATION_KEYS)
+    json_trace = _person_loc_trace(json_store, PATTERNS, 120)
+    bin_trace = _person_loc_trace(bin_store, bp, 120)
+
+    assert json_trace.keys() == bin_trace.keys()
+    for ts in json_trace:
+        assert np.array_equal(json_trace[ts], bin_trace[ts]), ts
+
+
+def test_binary_items_reconstructs_legacy_shape():
+    """BinaryPatterns.items() must rebuild the {homes, places} dicts the
+    non-engine (event-queue) path consumes — and, because PATTERNS' per-location
+    lists are already person-id-sorted, reproduce them in byte-identical ORDER
+    (list equality is order-sensitive). This is the non-engine equivalence
+    guarantee for a producer whose lists are sorted (the current producer's are).
+    """
+    M, ts, pids, loc_ids, n_homes = build_arrays_from_legacy(PATTERNS, PAPDATA)
+    bp = decode_patterns_binary(encode_patterns_binary(M, ts, pids, loc_ids, n_homes))
+    assert dict(bp.items()) == PATTERNS
+
+
+def test_items_canonicalizes_order_to_person_columns():
+    """If a producer's lists are NOT person-sorted, items() returns the canonical
+    person-column order (the format does not preserve arbitrary list order). The
+    engine path is order-independent; the non-engine path is then only ensemble-
+    (not byte-) equivalent — this test pins the documented canonicalization."""
+    unsorted = {"60": {"homes": {"1": ["3", "1"]}, "places": {}}, "120": {"homes": {"1": ["1", "3"]}, "places": {}}}
+    pap = {"people": {"1": {}, "3": {}}, "homes": {"1": {}}, "places": {}}
+    M, ts, pids, loc_ids, n_homes = build_arrays_from_legacy(unsorted, pap)
+    bp = decode_patterns_binary(encode_patterns_binary(M, ts, pids, loc_ids, n_homes))
+    # Both timesteps come back in person-column (sorted-by-int) order: ["1", "3"].
+    assert dict(bp.items())["60"]["homes"]["1"] == ["1", "3"]
+    assert dict(bp.items())["120"]["homes"]["1"] == ["1", "3"]
+
+
+def test_empty_id_table_round_trips_to_empty_list():
+    """An empty id table must decode to [] (not [''])."""
+    M = np.zeros((2, 0), dtype=np.uint16)
+    bp = decode_patterns_binary(encode_patterns_binary(M, [60, 120], [], ["1"], 1))
+    assert bp.pids == []
+    assert bp.loc_matrix.shape == (2, 0)
+
+
+def test_beyond_window_location_is_tolerated():
+    """A producer location referenced only beyond max_length and absent from the
+    consumer's space must NOT crash precompute (mirrors the legacy loop)."""
+    pat = {"60": {"homes": {"1": ["1"], "2": ["2"]}, "places": {"1": ["3"]}},
+           "120": {"homes": {"1": ["1", "2"]}, "places": {"1": ["3"]}}}
+    bp = decode_patterns_binary(
+        encode_patterns_binary(*build_arrays_from_legacy(pat, PAPDATA))
+    )
+    # Inject an extra producer location used by no in-window cell.
+    store = MembershipStore(PEOPLE, LOCATION_KEYS)
+    store.precompute_movement(bp, 60)  # window stops before any odd location
+    assert set(store._move) == {60}
+
+
+def test_max_length_gating():
+    M, ts, pids, loc_ids, n_homes = build_arrays_from_legacy(PATTERNS, PAPDATA)
+    bp = decode_patterns_binary(encode_patterns_binary(M, ts, pids, loc_ids, n_homes))
+    store = MembershipStore(PEOPLE, LOCATION_KEYS)
+    store.precompute_movement(bp, 60)  # only the first timestep
+    assert set(store._move) == {60}


### PR DESCRIPTION
## What this ships
The full single-run performance effort for ~50k-population simulations (15 commits). On the 50k Barnsdall fixture: the non-engine path ran ~175–334s; engine mode runs ~13s end-to-end (~13–28×).

- **SoA "engine mode"** — struct-of-arrays + NumPy movement and a vectorized single-variant Wells-Riley transmission kernel.
- **Engine is now the DEFAULT** (`47abec4`) with eligibility routing + graceful fallback: it engages only when the run is correct for it (single variant, no movement-altering intervention, aggregate transmission on, logging off) and **transparently falls back to the non-engine path otherwise** (no silent-wrong results, no crashes). Kill switch: `DELINEO_SOA_ENGINE=0`.
- **Binary columnar patterns input** (`DLNOPAT1`) — input load ~85s → ~0.11s; consumer **auto-detects JSON vs binary**, so old zones keep working.
- **Incremental per-step loops** (#2/#3) — incremental variant-tracking + sparse state updates; ~2× on saturating runs.
- **Per-place dot counts** (`pdots`) — engine emits per-place [infected, recovered] so the Fullstack Cases-map bake is a passthrough instead of a per-person loop.

## Safety / validation
- Representation-only refactors proven **byte-identical** (canonical-hash golden, full 720-step run); RNG-stream-changing kernels validated by **ensemble** equivalence. **96 tests green.**
- Engine default-on is guarded by eligibility + fallback (validated: lockdown now respected, multi-variant falls back, byte-identical fallback to the pure non-engine path).

## ⚠️ Deploy notes (main autodeploys to the public site)
- This is the **Simulation consumer**. The **Algorithms producer** (binary-patterns *emit*) is a **separate repo/PR** (`ryad/columnar-patterns-zstd`). The consumer auto-detects both formats, so **deploying this before/without the producer is safe**; producer kill switch is `DELINEO_PATTERNS_BINARY=0`.
- Pairs with Fullstack PR (cases-map per-place dots + binary patterns transport).
- Engine-default-on changes production run behavior (validated, with the `=0` kill switch). Please review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)