### PR TITLE
External force-of-infection term in the Wells-Riley kernel (default off)

### DIFF
--- a/simulator/config.py
+++ b/simulator/config.py
@@ -85,6 +85,27 @@ INFECTION_MODEL = {
     # the observed footprint distribution.
     "area_clamp_min": float(os.environ.get("DELINEO_AREA_CLAMP_MIN", "65.0")),
     "area_clamp_max": float(os.environ.get("DELINEO_AREA_CLAMP_MAX", "70000.0")),
+    # External force-of-infection term (open-system coupling). ~85% of a POI's
+    # real visitors live outside the simulated cluster; rather than simulate them,
+    # they contribute a one-way background quanta source at each POI. The external
+    # headcount is reconstructed from the already-simulated internal occupancy:
+    # external = n_internal x (1 - f_j)/f_j, where f_j (catchment_fj, emitted by
+    # popgen) is the in-cluster visitor share. Those externals act as extra
+    # well-mixed infectors with probability external_prevalence of being infectious
+    # (one-way: never simulated as agents, never susceptible, never rendered).
+    # See docs/MOVEMENT_MODEL_REDESIGN.md (Algorithms) §10.
+    # DEFAULT OFF (and external_prevalence defaults to 0, so even flagged-on it is
+    # inert) -> golden run bit-identical until deliberately calibrated. Override
+    # per run via the simdata "external_foi" / "external_prevalence" fields.
+    "external_foi": os.environ.get("DELINEO_EXTERNAL_FOI", "0").lower()
+    in {"1", "true", "yes", "on"},
+    # P_ext: exogenous probability a given external visitor is infectious. A scalar
+    # for now (calibrate against real case data; can grow into a time series). NOT
+    # tied to the sim's own prevalence (that re-closes the system / feeds back).
+    "external_prevalence": float(os.environ.get("DELINEO_EXTERNAL_PREVALENCE", "0.0")),
+    # Average emission factor of an external visitor relative to an unmasked,
+    # unvaccinated internal infector (community masking / behaviour). 1.0 = same.
+    "external_emit_factor": float(os.environ.get("DELINEO_EXTERNAL_EMIT_FACTOR", "1.0")),
     # Fallback timeline values used only when DMP API fails to provide a timeline
     "fallback_timeline": {
         "infected_duration": 1440,      # 24 hours in minutes (fallback value)

--- a/simulator/pap.py
+++ b/simulator/pap.py
@@ -52,6 +52,7 @@ class Location:
         capacity: int = -1,
         location_type: str = "unknown",
         area: Optional[float] = None,
+        catchment_fj: Optional[float] = None,
     ) -> None:
         self.id: str = str(id)
         self.cbg: Optional[str] = cbg
@@ -59,6 +60,10 @@ class Location:
         self.capacity: int = capacity        # -1 = unlimited
         self.location_type: str = location_type
         self.area: Optional[float] = area    # physical floor area in m^2 (None = unknown)
+        # In-cluster visitor share f_j (popgen catchment_fj). Drives the external
+        # force-of-infection term: external occupancy = internal x (1 - f_j)/f_j.
+        # None = unknown (no external term applied). See config.external_foi.
+        self.catchment_fj: Optional[float] = catchment_fj
         self.population: dict[str, Person] = {}
         # SoA shadow (Step 1): when a MembershipStore is attached, add_member
         # also records the placement into person_loc. Left None in production so
@@ -117,8 +122,10 @@ class Facility(Location):
         capacity: int = -1,
         street_address: Optional[str] = None,
         area: Optional[float] = None,
+        catchment_fj: Optional[float] = None,
     ) -> None:
-        super().__init__(id=id, cbg=cbg, label=label, capacity=capacity, location_type="facility", area=area)
+        super().__init__(id=id, cbg=cbg, label=label, capacity=capacity,
+                         location_type="facility", area=area, catchment_fj=catchment_fj)
         self.street_address: Optional[str] = street_address
 
 

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -523,6 +523,20 @@ class SimulationRunner:
                 )
             else:
                 logger.info("SoA engine engaged (eligible config).")
+        # The external-FOI term is implemented in the SoA engine kernel only
+        # (the default-on path). Warn loudly rather than silently no-op if a run
+        # asks for it but won't use the engine.
+        if (
+            self.external_foi
+            and self.external_prevalence > 0.0
+            and not self._soa_engine
+        ):
+            logger.warning(
+                "external_foi is ON (external_prevalence=%.4g) but this run is not "
+                "using the SoA engine — the external term will have NO effect. It is "
+                "currently implemented in _vectorized_transmission only.",
+                self.external_prevalence,
+            )
         # Single-variant engine mode derives infectious locations from occupancy,
         # so the event queue / _person_index (build_event_queue) is unnecessary.
         engine_no_queue = self._soa_engine and len(variants) == 1

--- a/simulator/runner.py
+++ b/simulator/runner.py
@@ -148,6 +148,20 @@ def normalize_simdata(simdata: dict) -> dict:
         )
     )
 
+    normalized["external_foi"] = bool(
+        normalized.get("external_foi", INFECTION_MODEL.get("external_foi", False))
+    )
+    normalized["external_prevalence"] = float(
+        normalized.get(
+            "external_prevalence", INFECTION_MODEL.get("external_prevalence", 0.0)
+        )
+    )
+    normalized["external_emit_factor"] = float(
+        normalized.get(
+            "external_emit_factor", INFECTION_MODEL.get("external_emit_factor", 1.0)
+        )
+    )
+
     raw_model_paths = normalized.get("model_path_by_variant") or {}
     model_path_by_variant = {}
     if isinstance(raw_model_paths, dict):
@@ -337,6 +351,14 @@ class SimulationRunner:
             float(INFECTION_MODEL.get("area_clamp_min", 65.0)),
             float(INFECTION_MODEL.get("area_clamp_max", 70000.0)),
         )
+        # External force-of-infection term (default off → golden preserved). When
+        # on, each facility gets a one-way background quanta source from its
+        # external (out-of-cluster) visitors; see _external_emission_per_loc and
+        # _vectorized_transmission. external_prevalence (P_ext) defaults to 0, so
+        # the term is inert until calibrated even when the flag is on.
+        self.external_foi = self.simdata["external_foi"]
+        self.external_prevalence = float(self.simdata["external_prevalence"])
+        self.external_emit_factor = float(self.simdata["external_emit_factor"])
         self._perf_accum: dict[str, float] = {}
         self._soa_engine: bool = False
         self._soa_shadow: bool = False
@@ -567,12 +589,27 @@ class SimulationRunner:
             # vectorized kernel needs no per-room work at runtime.
             exposure_hours = simulator.timestep / 60.0
             base_q = np.empty(store.num_locations, dtype=np.float64)
+            # Static external-FOI coefficient per location: (1 - f_j)/f_j * emit
+            # factor. At runtime W_external[loc] = n_internal[loc] * ext_ratio[loc]
+            # * P_ext, so the externals act as extra well-mixed infectors. 0 for
+            # households and for facilities with unknown f_j (no term applied).
+            build_ext = self.external_foi
+            ext_ratio = (
+                np.zeros(store.num_locations, dtype=np.float64) if build_ext else None
+            )
             for loc_idx, (loc_id, is_hh) in enumerate(store.idx_to_loc):
                 place = simulator.get_location(loc_id, is_hh)
                 base_q[loc_idx] = (20.0 * 0.5 * exposure_hours) / self._ventilation_rate(
                     place, is_hh
                 )
+                if build_ext and not is_hh:
+                    fj = getattr(place, "catchment_fj", None)
+                    if fj is not None and 0.0 < fj <= 1.0:
+                        ext_ratio[loc_idx] = (
+                            (1.0 - fj) / fj * self.external_emit_factor
+                        )
             store.base_quanta = base_q
+            store.ext_ratio = ext_ratio
 
         return SimulationContext(
             simulator=simulator,
@@ -974,7 +1011,21 @@ class SimulationRunner:
         )
         placed = person_loc >= 0
         infectious = placed & ((pstate & INFECTIOUS) != 0)
-        if not infectious.any():
+
+        # External force-of-infection: out-of-cluster visitors add a one-way
+        # background emission to each room, W_ext[loc] = n_internal[loc]
+        # * ext_ratio[loc] * P_ext, where ext_ratio = (1 - f_j)/f_j * emit_factor.
+        # The externals are never agents (not in pstate / never susceptible /
+        # never rendered), so this can seed or sustain transmission with zero
+        # internal infectors present — which is exactly why we must NOT early-return
+        # on infectious.any() when the term is active. Inert by default (flag off,
+        # or external_prevalence 0, or ext_ratio unbuilt) -> golden path preserved.
+        ext_on = (
+            self.external_foi
+            and self.external_prevalence > 0.0
+            and store.ext_ratio is not None
+        )
+        if not infectious.any() and not ext_on:
             return
 
         # Emission weight per infector, summed per room (cheap O(N) numpy).
@@ -983,11 +1034,15 @@ class SimulationRunner:
         W = np.bincount(
             person_loc[placed], weights=emit[placed], minlength=store.num_locations
         )
+        if ext_on:
+            # n_internal = realized internal occupancy per room (all placed people).
+            n_internal = np.bincount(person_loc[placed], minlength=store.num_locations)
+            W = W + store.ext_ratio * n_internal * self.external_prevalence
 
         # Restrict the expensive trials (exp + RNG + scheduling) to actually
-        # exposed susceptibles — those placed in a room with infectors. This keeps
-        # the kernel cheap at low prevalence (few eligible) and at saturation
-        # (numpy), instead of drawing for all N every timestep.
+        # exposed susceptibles — those placed in a room with infectors (or external
+        # pressure). This keeps the kernel cheap at low prevalence (few eligible)
+        # and at saturation (numpy), instead of drawing for all N every timestep.
         loc = np.where(placed, person_loc, 0)
         room_W = W[loc]
         eligible = placed & (pstate == 0) & ((pstate & INVISIBLE) == 0) & (room_W > 0.0)

--- a/simulator/world.py
+++ b/simulator/world.py
@@ -82,6 +82,7 @@ def parse_cbg(data) -> Optional[str]:
 
 def parse_facility(fid: str, data) -> Facility:
     area = None
+    catchment_fj = None
     if isinstance(data, list) and len(data) >= 2:
         cbg = data[0] if data else None
         label = data[1] if len(data) > 1 else None
@@ -93,6 +94,7 @@ def parse_facility(fid: str, data) -> Facility:
         capacity = data.get("capacity", -1)
         street_address = data.get("street_address")
         area = data.get("area")
+        catchment_fj = data.get("catchment_fj")
     else:
         cbg = data
         label = f"Place_{fid}"
@@ -113,7 +115,16 @@ def parse_facility(fid: str, data) -> Facility:
         except (TypeError, ValueError):
             area = None
 
-    return Facility(str(fid), cbg, label, capacity, street_address=street_address, area=area)
+    if catchment_fj is not None:
+        try:
+            catchment_fj = float(catchment_fj)
+            if not (0.0 < catchment_fj <= 1.0):
+                catchment_fj = None
+        except (TypeError, ValueError):
+            catchment_fj = None
+
+    return Facility(str(fid), cbg, label, capacity, street_address=street_address,
+                    area=area, catchment_fj=catchment_fj)
 
 
 def build_locations(simulator: DiseaseSimulator, homes_data: dict, places_data: dict) -> None:

--- a/tests/test_external_foi.py
+++ b/tests/test_external_foi.py
@@ -1,0 +1,133 @@
+"""External force-of-infection term (open-system coupling).
+
+The ~85% of a POI's real visitors who live outside the simulated cluster are
+represented as a one-way background quanta source rather than as agents:
+W_external[loc] = n_internal[loc] * (1 - f_j)/f_j * emit_factor * P_ext, added to
+each room's well-mixed emission in the SoA engine kernel. f_j (catchment_fj) is
+emitted per-POI by popgen. These tests pin: the term is inert by default and when
+P_ext=0 (golden preserved), it can seed infections from zero internal seed when
+on, it scales with P_ext, and households (no f_j) get no external term.
+
+Design: Algorithms docs/MOVEMENT_MODEL_REDESIGN.md §10.
+"""
+import unittest
+
+from simulator.runner import LoadedSimulationData, SimulationRunner, normalize_simdata
+from simulator.world import parse_facility
+from simulator.config import INFECTION_MODEL
+
+_N = 24
+
+
+def _loaded(at_facility: bool, fj=0.1):
+    homes_data = {"1": {"cbg": "cbg-home"}}
+    # facility id must be numeric (engine sorts facilities by int(id)) and
+    # distinct from the home id to avoid the home/place id space colliding.
+    places_data = (
+        {"1001": {"cbg": "cbg-f1", "label": "Shop", "catchment_fj": fj}}
+        if at_facility else {}
+    )
+    pids = [str(i) for i in range(_N)]
+    slot = (
+        {"homes": {}, "places": {"1001": pids}}
+        if at_facility else {"homes": {"1": pids}, "places": {}}
+    )
+    patterns_data = {str(t): slot for t in (60, 120, 180, 240, 300)}
+    people_data = {p: {"sex": int(p) % 2, "age": 30, "home": "1"} for p in pids}
+    return LoadedSimulationData(
+        people_data=people_data, homes_data=homes_data,
+        places_data=places_data, patterns_data=patterns_data,
+    )
+
+
+def _simdata(external_foi, external_prevalence, seeds):
+    return {
+        "czone_id": 1, "length": 300, "randseed": False,
+        "initial_infected_count": seeds, "disease_name": "COVID-19",
+        "variants": ["Delta"], "dmp_mode": "off",
+        "external_foi": external_foi, "external_prevalence": external_prevalence,
+        "interventions": [{"time": 0, "mask": 0.0, "vaccine": 0.0,
+                           "capacity": 1.0, "lockdown": 0.0, "selfiso": 0.0}],
+    }
+
+
+def _ever_infected(external_foi=False, external_prevalence=0.0, seeds=0,
+                   at_facility=True, fj=0.1):
+    runner = SimulationRunner(_simdata(external_foi, external_prevalence, seeds),
+                              enable_logging=False)
+    runner._seed_random()
+    context = runner.build_context(_loaded(at_facility, fj=fj))
+    assert runner._soa_engine, "single-variant no-intervention run should use the engine"
+    runner.run_queue(context)
+    return len(context.infection_manager.infected)
+
+
+class ExternalFoiKernelTest(unittest.TestCase):
+    def test_off_no_spontaneous_infection(self):
+        # flag off + zero seed -> closed system, nothing happens (golden).
+        self.assertEqual(_ever_infected(external_foi=False, seeds=0), 0)
+
+    def test_seeds_from_zero_internal_seed(self):
+        # flag on + P_ext>0 + zero internal seed -> the external term alone seeds
+        # an outbreak (the open-system cold-start the design is about).
+        n = _ever_infected(external_foi=True, external_prevalence=0.2, seeds=0)
+        self.assertGreater(n, 0)
+
+    def test_inert_when_prevalence_zero(self):
+        # flag ON but P_ext=0 -> inert (the v1 "default 0 = inert" guarantee).
+        self.assertEqual(
+            _ever_infected(external_foi=True, external_prevalence=0.0, seeds=0), 0
+        )
+
+    def test_scales_with_prevalence(self):
+        lo = _ever_infected(external_foi=True, external_prevalence=0.02, seeds=0)
+        hi = _ever_infected(external_foi=True, external_prevalence=0.2, seeds=0)
+        self.assertGreaterEqual(hi, lo)
+        self.assertGreater(hi, 0)
+
+    def test_households_get_no_external_term(self):
+        # Everyone stays home (a household, no f_j) with the term on -> ext_ratio
+        # is 0 for households, so no external infection.
+        self.assertEqual(
+            _ever_infected(external_foi=True, external_prevalence=0.2, seeds=0,
+                           at_facility=False),
+            0,
+        )
+
+    def test_amplifies_an_existing_seed(self):
+        off = _ever_infected(external_foi=False, seeds=2)
+        on = _ever_infected(external_foi=True, external_prevalence=0.2, seeds=2)
+        self.assertGreaterEqual(on, off)
+
+
+class ExternalFoiPlumbingTest(unittest.TestCase):
+    def test_parse_facility_catchment_fj(self):
+        self.assertEqual(
+            parse_facility("a", {"cbg": "c", "catchment_fj": 0.25}).catchment_fj, 0.25
+        )
+        # out-of-range / unparseable -> None (no term applied)
+        self.assertIsNone(parse_facility("b", {"cbg": "c", "catchment_fj": 0}).catchment_fj)
+        self.assertIsNone(parse_facility("c", {"cbg": "c", "catchment_fj": 1.5}).catchment_fj)
+        self.assertIsNone(parse_facility("d", {"cbg": "c", "catchment_fj": "x"}).catchment_fj)
+        self.assertIsNone(parse_facility("e", {"cbg": "c"}).catchment_fj)
+
+    def test_normalize_simdata_defaults_and_overrides(self):
+        d = normalize_simdata({"czone_id": 1, "length": 1,
+                               "interventions": [{"time": 0}]})
+        self.assertEqual(d["external_foi"], INFECTION_MODEL["external_foi"])
+        self.assertEqual(d["external_prevalence"], INFECTION_MODEL["external_prevalence"])
+        self.assertEqual(d["external_emit_factor"], INFECTION_MODEL["external_emit_factor"])
+        d2 = normalize_simdata({"czone_id": 1, "length": 1, "interventions": [{"time": 0}],
+                                "external_foi": True, "external_prevalence": 0.01,
+                                "external_emit_factor": 0.5})
+        self.assertTrue(d2["external_foi"])
+        self.assertEqual(d2["external_prevalence"], 0.01)
+        self.assertEqual(d2["external_emit_factor"], 0.5)
+
+    def test_default_config_is_off_and_inert(self):
+        self.assertFalse(INFECTION_MODEL["external_foi"])
+        self.assertEqual(INFECTION_MODEL["external_prevalence"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this does

Adds a one-way **external force-of-infection** term to the Wells-Riley kernel (open-system coupling). The ~85% of a POI's real visitors who live outside the simulated cluster contribute a one-way background quanta source instead of being simulated as agents:

```
W_external[loc] = n_internal[loc] × (1 − f_j)/f_j × emit_factor × P_ext
```

added to each room's emission in `_vectorized_transmission`. The externals act as extra well-mixed infectors but are **never agents** (not in `pstate`, never susceptible, never rendered as dots), so the term can seed/sustain transmission even with zero internal infectors present.

## Default OFF — golden run preserved

`external_foi` defaults **off**, and `external_prevalence` (P_ext) defaults **0** (inert even if the flag is on). **The full 94-test suite passes unchanged.** This PR is a no-op on prod until deliberately calibrated.

## Consumes `catchment_fj`

`f_j` per POI is emitted by Algorithms (`ryad/movement-redesign`). With the flag off this PR is independent and safe to merge in any order.

## Verification

- 94-test suite passes unchanged (golden preserved)
- End-to-end on real Barnsdall (czone-107): flag on + **zero internal seed → the external term alone seeds an outbreak**; `P_ext=0` → inert; households get no term
- 9 fixture-free regression tests in `tests/test_external_foi.py`

## Scope / limitation

Implemented in the SoA engine kernel (the default-on, every-timestep path) only; the non-engine pairwise/aggregate paths don't carry it yet (those are infection-gated, so they couldn't cold-start-seed anyway). A run that requests the term but falls back off-engine logs a warning. Non-engine coverage is a follow-up.

Design: Algorithms `docs/MOVEMENT_MODEL_REDESIGN.md` §10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)